### PR TITLE
fix(scripts): Can't found `/bin/bash` in NixOS

### DIFF
--- a/config/ags/scripts/cpu.sh
+++ b/config/ags/scripts/cpu.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Get the CPU usage percentage using the 'top' command
 cpu_usage=$(mpstat -P ALL 1 1 | awk 'END {print 100 - $NF}')

--- a/config/ags/scripts/cpu_cores.sh
+++ b/config/ags/scripts/cpu_cores.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Get the CPU usage percentage for each core using 'mpstat'
 cpu_usages=($(mpstat -P ALL 1 1 | awk '/^Average:/ && $12 != "all" {print 100 - $NF}'))

--- a/config/ags/scripts/cpu_usage.sh
+++ b/config/ags/scripts/cpu_usage.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Get the number of CPU cores
 num_cores=$(nproc)

--- a/config/ags/scripts/devices_temps.sh
+++ b/config/ags/scripts/devices_temps.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 sensor_data=$(sensors -u)
 

--- a/config/ags/scripts/get_wallpapers.sh
+++ b/config/ags/scripts/get_wallpapers.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 folder=$1 # Get the folder path from the first argument
 

--- a/config/ags/scripts/hardware_info.sh
+++ b/config/ags/scripts/hardware_info.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Check if upower is installed
 if ! command -v upower &> /dev/null; then

--- a/config/ags/scripts/net_usage.sh
+++ b/config/ags/scripts/net_usage.sh
@@ -1,5 +1,5 @@
 
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Get all network connections and their associated PIDs (requires root privileges)
 sudo netstat -tulnp | awk 'NR > 2 {print $7}' | awk -F '/' '{print $1, $NF}' > /tmp/connections.txt

--- a/config/ags/scripts/ram.sh
+++ b/config/ags/scripts/ram.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Check if the 'free' command is available
 if ! command -v free &> /dev/null; then

--- a/config/ags/scripts/ram_usage.sh
+++ b/config/ags/scripts/ram_usage.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Get the top 10 processes using the most RAM
 top_processes=$(ps -eo pid,%mem,comm --sort=-%mem | head -n 11 | tail -n +2)

--- a/config/ags/scripts/system_info.sh
+++ b/config/ags/scripts/system_info.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Function to get kernel version
 get_kernel_version() {

--- a/config/ags/scripts/temp.sh
+++ b/config/ags/scripts/temp.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Check if lm-sensors is installed
 if ! command -v sensors &> /dev/null; then

--- a/config/ags/scripts/uptime.sh
+++ b/config/ags/scripts/uptime.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 uptime_seconds=$(cut -d ' ' -f 1 /proc/uptime)
 uptime_hours=$(echo "$uptime_seconds / 3600" | bc)

--- a/scripts/battery.sh
+++ b/scripts/battery.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Get battery status
 battery_info=$(acpi -b)

--- a/scripts/convert_to_png.sh
+++ b/scripts/convert_to_png.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Check if the input argument is provided
 if [ -z "$1" ]; then

--- a/scripts/get_minimized.sh
+++ b/scripts/get_minimized.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 CURRENT_WORKSPACE=$(hyprctl activeworkspace -j | jq '.id')
 

--- a/scripts/minimiz.sh
+++ b/scripts/minimiz.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 CURRENT_WORKSPACE=$(hyprctl activeworkspace -j | jq '.id')
 

--- a/scripts/playerctl.sh
+++ b/scripts/playerctl.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Check if the correct number of arguments is provided
 if [ $# -ne 1 ]; then

--- a/scripts/wrapper.sh
+++ b/scripts/wrapper.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd~
 


### PR DESCRIPTION
In NixOS, only a symbolic link to the 'sh' binary, so scripts can't found bash in /bin directory. I use `/usr/bin/env bash` to instead of `/bin/bash`.