### PR TITLE
feat: add bottom app launcher with configurable mode toggle

### DIFF
--- a/config/quickshell/bars/LeftBar.qml
+++ b/config/quickshell/bars/LeftBar.qml
@@ -11,6 +11,7 @@ import "root:/utils"
 import "root:/services"
 import "root:/config/EventNames.js" as Events
 import "root:/config"
+import "root:/config/ConstValues.js" as Consts
 
 PanelWindow {
     id: root
@@ -202,6 +203,15 @@ PanelWindow {
                 bottomButtonGroup.currentIndex = -1;
 
             const globalIndex = offset + localIndex;
+
+            // Check if this is the apps button and bottom launcher is enabled
+            if (globalIndex === Consts.APPLICATIONS_MENU_INDEX && App.useBottomLauncher) {
+                // Reset selection and toggle bottom launcher instead
+                bottomButtonGroup.currentIndex = -1;
+                EventBus.emit(Events.TOGGLE_BOTTOM_LAUNCHER);
+                return;
+            }
+
             root.activeMenuIndex = globalIndex;
 
             if (!root.panelOpen) {

--- a/config/quickshell/components/CommandItem.qml
+++ b/config/quickshell/components/CommandItem.qml
@@ -1,0 +1,115 @@
+// components/CommandItem.qml
+import QtQuick
+
+import "root:/themes"
+
+Item {
+    id: root
+
+    property var commandData
+    property bool isHighlighted: false
+
+    signal clicked
+
+    height: 56
+
+    Rectangle {
+        id: hoverBg
+        anchors.fill: parent
+        radius: ThemeManager.selectedTheme?.dimensions?.elementRadius || 8
+
+        color: {
+            if (root.isHighlighted) {
+                return ThemeManager.selectedTheme?.colors?.primary.alpha(0.2) || "#333";
+            }
+            if (mouseArea.containsMouse) {
+                return ThemeManager.selectedTheme?.colors?.primary.alpha(0.1) || "#222";
+            }
+            return "transparent";
+        }
+
+        border.color: root.isHighlighted 
+            ? ThemeManager.selectedTheme?.colors?.primary || "#6366f1"
+            : "transparent"
+        border.width: root.isHighlighted ? 1 : 0
+
+        Behavior on color {
+            ColorAnimation { duration: 150; easing.type: Easing.OutQuad }
+        }
+
+        Behavior on border.color {
+            ColorAnimation { duration: 150 }
+        }
+    }
+
+    // Icon container - fixed position
+    Rectangle {
+        id: iconContainer
+        anchors.left: parent.left
+        anchors.leftMargin: 12
+        anchors.verticalCenter: parent.verticalCenter
+        width: 40
+        height: 40
+        radius: (ThemeManager.selectedTheme?.dimensions?.elementRadius || 8) * 0.8
+        color: ThemeManager.selectedTheme?.colors?.leftMenuBgColorV2 || "#1a1a2e"
+
+        Text {
+            anchors.centerIn: parent
+            text: commandData?.icon || ""
+            font.pixelSize: 20
+            font.family: ThemeManager.selectedTheme?.typography?.iconFont || "Material Design Icons"
+            color: ThemeManager.selectedTheme?.colors?.primary || "#6366f1"
+        }
+    }
+
+    // Text content - fixed left anchor
+    Column {
+        anchors.left: iconContainer.right
+        anchors.leftMargin: 12
+        anchors.right: parent.right
+        anchors.rightMargin: 48
+        anchors.verticalCenter: parent.verticalCenter
+        spacing: 2
+
+        Text {
+            text: commandData?.name || ""
+            font.pixelSize: 13
+            font.weight: Font.Medium
+            color: ThemeManager.selectedTheme?.colors?.leftMenuFgColorV1 || "#fff"
+        }
+
+        Text {
+            text: commandData?.description || ""
+            font.pixelSize: 11
+            color: ThemeManager.selectedTheme?.colors?.subtleText || "#888"
+        }
+    }
+
+    // Enter hint - positioned absolutely
+    Rectangle {
+        anchors.right: parent.right
+        anchors.rightMargin: 12
+        anchors.verticalCenter: parent.verticalCenter
+        width: 24
+        height: 24
+        radius: 4
+        color: ThemeManager.selectedTheme?.colors?.leftMenuBgColorV2 || "#1a1a2e"
+        visible: mouseArea.containsMouse || root.isHighlighted
+        opacity: 0.8
+
+        Text {
+            anchors.centerIn: parent
+            text: "↵"
+            font.pixelSize: 12
+            color: ThemeManager.selectedTheme?.colors?.subtleText || "#888"
+        }
+    }
+
+    MouseArea {
+        id: mouseArea
+        anchors.fill: parent
+        hoverEnabled: true
+        cursorShape: Qt.PointingHandCursor
+        onClicked: root.clicked()
+    }
+}

--- a/config/quickshell/components/WallpaperSelector.qml
+++ b/config/quickshell/components/WallpaperSelector.qml
@@ -6,7 +6,6 @@ import QtQuick.Controls
 import QtQuick.Layouts
 import Quickshell
 import Quickshell.Io
-import Qt.labs.platform
 
 import "root:/themes"
 import "root:/components"
@@ -31,9 +30,9 @@ Item {
     property int sourceMode: 0 // 0 = Local, 1 = Custom, 2 = Wallhaven
 
     property var localWallpapers: []
-    property var customWallpapers: []
+    property var downloadedWallpapers: []
     property var wallhavenWallpapers: []
-    property string customFolderPath: ThemeManager.selectedTheme?.systemSettings?.dynamicWallpapersPath || ""
+    property string downloadedFolderPath: App.cacheFolderPath + "/wallpapers"
 
     // Wallhaven settings
     property string wallhavenQuery: ""
@@ -106,11 +105,11 @@ Item {
         { name: "UW QHD", value: "3440x1440" }
     ]
 
-    property var sourceNames: ["Local", "Custom", "Wallhaven"]
+    property var sourceNames: ["Local", "Downloaded", "Wallhaven"]
 
     property var currentWallpapers: {
         if (sourceMode === 0) return localWallpapers;
-        if (sourceMode === 1) return customWallpapers;
+        if (sourceMode === 1) return downloadedWallpapers;
         return wallhavenWallpapers;
     }
 
@@ -128,9 +127,7 @@ Item {
 
     Component.onCompleted: {
         loadLocalWallpapers();
-        if (customFolderPath !== "") {
-            loadCustomWallpapers();
-        }
+        loadDownloadedWallpapers();
     }
 
     function loadLocalWallpapers() {
@@ -138,10 +135,9 @@ Item {
         localWallpapersProcess.running = true;
     }
 
-    function loadCustomWallpapers() {
-        if (customFolderPath === "") return;
-        customWallpapersProcess.command = Helper.getWallpapersList(customFolderPath);
-        customWallpapersProcess.running = true;
+    function loadDownloadedWallpapers() {
+        downloadedWallpapersProcess.command = Helper.getWallpapersList(downloadedFolderPath);
+        downloadedWallpapersProcess.running = true;
     }
 
     function searchWallhaven(resetPage) {
@@ -245,15 +241,15 @@ Item {
     }
 
     Process {
-        id: customWallpapersProcess
+        id: downloadedWallpapersProcess
         stdout: StdioCollector {
             onStreamFinished: {
                 try {
                     const list = JSON.parse(this.text);
-                    root.customWallpapers = list || [];
+                    root.downloadedWallpapers = list || [];
                 } catch (e) {
-                    console.error("WallpaperSelector: Failed to parse custom wallpapers", e);
-                    root.customWallpapers = [];
+                    console.error("WallpaperSelector: Failed to parse downloaded wallpapers", e);
+                    root.downloadedWallpapers = [];
                 }
             }
         }
@@ -302,19 +298,11 @@ Item {
         onExited: (exitCode, exitStatus) => {
             if (exitCode === 0 && wallpaperPath !== "") {
                 root.applyWallpaper(wallpaperPath);
+                // Refresh downloaded list after successful download
+                root.loadDownloadedWallpapers();
             } else {
                 console.error("WallpaperSelector: Download failed with exit code", exitCode);
             }
-        }
-    }
-
-    FolderDialog {
-        id: folderDialog
-        title: "Select Wallpapers Folder"
-        onAccepted: {
-            var path = folder.toString().replace("file://", "");
-            root.customFolderPath = path;
-            root.loadCustomWallpapers();
         }
     }
 
@@ -349,33 +337,6 @@ Item {
                     text: sourceMode === 2 ? qsTr("Browse wallpapers from Wallhaven.cc") : qsTr("Select a wallpaper to apply")
                     font.pixelSize: 11
                     color: ThemeManager.selectedTheme?.colors?.subtleText || "#888"
-                }
-            }
-
-            // Settings button (for custom folder)
-            Rectangle {
-                width: 28
-                height: 28
-                radius: 6
-                visible: root.sourceMode === 1
-                color: settingsMouseArea.containsMouse 
-                    ? ThemeManager.selectedTheme?.colors?.primary.alpha(0.2) || "#333"
-                    : "transparent"
-
-                Text {
-                    anchors.centerIn: parent
-                    text: "󰉋"
-                    font.pixelSize: 16
-                    font.family: ThemeManager.selectedTheme?.typography?.iconFont || "Material Design Icons"
-                    color: ThemeManager.selectedTheme?.colors?.subtleText || "#888"
-                }
-
-                MouseArea {
-                    id: settingsMouseArea
-                    anchors.fill: parent
-                    hoverEnabled: true
-                    cursorShape: Qt.PointingHandCursor
-                    onClicked: folderDialog.open()
                 }
             }
 

--- a/config/quickshell/components/WallpaperSelector.qml
+++ b/config/quickshell/components/WallpaperSelector.qml
@@ -1,0 +1,1336 @@
+// components/WallpaperSelector.qml
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Quickshell
+import Quickshell.Io
+import Qt.labs.platform
+
+import "root:/themes"
+import "root:/components"
+import "root:/config"
+import "root:/utils"
+
+Item {
+    id: root
+
+    signal wallpaperSelected(string path)
+    signal closeRequested
+
+    // Catch clicks on blank areas to prevent closing the launcher
+    MouseArea {
+        anchors.fill: parent
+        onClicked: event => event.accepted = true
+    }
+
+    property bool compact: width < 400 // For sidebar use
+    property bool applyToAllMonitors: true
+    property string filterText: ""
+    property int sourceMode: 0 // 0 = Local, 1 = Custom, 2 = Wallhaven
+
+    property var localWallpapers: []
+    property var customWallpapers: []
+    property var wallhavenWallpapers: []
+    property string customFolderPath: ThemeManager.selectedTheme?.systemSettings?.dynamicWallpapersPath || ""
+
+    // Wallhaven settings
+    property string wallhavenQuery: ""
+    property string wallhavenCategory: "110" // General + Anime (no People)
+    property string wallhavenPurity: "100"   // sfw only
+    property string wallhavenSorting: "toplist"
+    property string wallhavenOrder: "desc" // desc or asc
+    property string wallhavenTopRange: "1M"
+    property string wallhavenColor: "" // Color filter (hex without #)
+    property int wallhavenPage: 1
+    property bool wallhavenLoading: false
+    property bool wallhavenHasMore: true
+
+    // Top range presets
+    property var topRangePresets: [
+        { name: "Day", value: "1d" },
+        { name: "3 Days", value: "3d" },
+        { name: "Week", value: "1w" },
+        { name: "Month", value: "1M" },
+        { name: "3 Months", value: "3M" },
+        { name: "6 Months", value: "6M" },
+        { name: "1 Year", value: "1y" }
+    ]
+
+    // Wallhaven color palette
+    property var colorPresets: [
+        { name: "Any", hex: "" },
+        { name: "Lonestar", hex: "660000" },
+        { name: "Red Berry", hex: "990000" },
+        { name: "Guardsman Red", hex: "cc0000" },
+        { name: "Persian Red", hex: "cc3333" },
+        { name: "French Rose", hex: "ea4c88" },
+        { name: "Plum", hex: "993399" },
+        { name: "Royal Purple", hex: "663399" },
+        { name: "Sapphire", hex: "333399" },
+        { name: "Science Blue", hex: "0066cc" },
+        { name: "Pacific Blue", hex: "0099cc" },
+        { name: "Downy", hex: "66cccc" },
+        { name: "Atlantis", hex: "77cc33" },
+        { name: "Limeade", hex: "669900" },
+        { name: "Verdun Green", hex: "336600" },
+        { name: "Verdun Green 2", hex: "666600" },
+        { name: "Olive", hex: "999900" },
+        { name: "Earls Green", hex: "cccc33" },
+        { name: "Yellow", hex: "ffff00" },
+        { name: "Sunglow", hex: "ffcc33" },
+        { name: "Orange Peel", hex: "ff9900" },
+        { name: "Blaze Orange", hex: "ff6600" },
+        { name: "Tuscany", hex: "cc6633" },
+        { name: "Potters Clay", hex: "996633" },
+        { name: "Nutmeg", hex: "663300" },
+        { name: "Black", hex: "000000" },
+        { name: "Dusty Gray", hex: "999999" },
+        { name: "Silver", hex: "cccccc" },
+        { name: "White", hex: "ffffff" },
+        { name: "Gun Powder", hex: "424153" }
+    ]
+
+    // Resolution filter
+    property string wallhavenResolution: "" // atleast resolution (e.g. "1920x1080")
+    property var resolutionPresets: [
+        { name: "Any", value: "" },
+        { name: "HD", value: "1280x720" },
+        { name: "FHD", value: "1920x1080" },
+        { name: "2K", value: "2560x1440" },
+        { name: "4K", value: "3840x2160" },
+        { name: "5K", value: "5120x2880" },
+        { name: "8K", value: "7680x4320" },
+        { name: "UW FHD", value: "2560x1080" },
+        { name: "UW QHD", value: "3440x1440" }
+    ]
+
+    property var sourceNames: ["Local", "Custom", "Wallhaven"]
+
+    property var currentWallpapers: {
+        if (sourceMode === 0) return localWallpapers;
+        if (sourceMode === 1) return customWallpapers;
+        return wallhavenWallpapers;
+    }
+
+    property var filteredWallpapers: {
+        if (sourceMode === 2) return currentWallpapers; // Wallhaven uses API search
+        if (!currentWallpapers || currentWallpapers.length === 0) return [];
+        if (filterText === "") return currentWallpapers;
+
+        const searchLower = filterText.toLowerCase();
+        return currentWallpapers.filter(path => {
+            const filename = (typeof path === 'string' ? path : path.path || "").split('/').pop().toLowerCase();
+            return filename.includes(searchLower);
+        });
+    }
+
+    Component.onCompleted: {
+        loadLocalWallpapers();
+        if (customFolderPath !== "") {
+            loadCustomWallpapers();
+        }
+    }
+
+    function loadLocalWallpapers() {
+        localWallpapersProcess.command = Helper.getWallpapersList(App.wallpapersPath);
+        localWallpapersProcess.running = true;
+    }
+
+    function loadCustomWallpapers() {
+        if (customFolderPath === "") return;
+        customWallpapersProcess.command = Helper.getWallpapersList(customFolderPath);
+        customWallpapersProcess.running = true;
+    }
+
+    function searchWallhaven(resetPage) {
+        if (wallhavenLoading) return;
+        
+        if (resetPage) {
+            wallhavenPage = 1;
+            wallhavenWallpapers = [];
+            wallhavenHasMore = true;
+        }
+
+        wallhavenLoading = true;
+        
+        let url = "https://wallhaven.cc/api/v1/search?";
+        url += "categories=" + wallhavenCategory;
+        url += "&purity=" + wallhavenPurity;
+        url += "&sorting=" + wallhavenSorting;
+        url += "&order=" + wallhavenOrder;
+        
+        if (wallhavenSorting === "toplist") {
+            url += "&topRange=" + wallhavenTopRange;
+        }
+        
+        if (wallhavenQuery !== "") {
+            url += "&q=" + encodeURIComponent(wallhavenQuery);
+        }
+
+        if (wallhavenColor !== "") {
+            url += "&colors=" + wallhavenColor;
+        }
+
+        if (wallhavenResolution !== "") {
+            url += "&atleast=" + wallhavenResolution;
+        }
+        
+        url += "&page=" + wallhavenPage;
+
+        wallhavenProcess.command = ["curl", "-s", url];
+        wallhavenProcess.running = true;
+    }
+
+    function loadMoreWallhaven() {
+        if (wallhavenLoading || !wallhavenHasMore) return;
+        wallhavenPage++;
+        searchWallhaven(false);
+    }
+
+    function selectWallpaper(wallpaperData) {
+        let path = "";
+        
+        if (sourceMode === 2) {
+            // Wallhaven - need to download first
+            if (typeof wallpaperData === 'object') {
+                path = wallpaperData.path;
+                // Download to cache folder
+                downloadWallhaven(wallpaperData);
+                return;
+            }
+        } else {
+            path = typeof wallpaperData === 'string' ? wallpaperData : wallpaperData.path;
+        }
+
+        applyWallpaper(path);
+    }
+
+    function downloadWallhaven(wallpaperData) {
+        const filename = wallpaperData.id + "." + wallpaperData.file_type.split('/')[1];
+        const cachePath = App.cacheFolderPath + "/wallpapers";
+        const filePath = cachePath + "/" + filename;
+
+        // Create cache dir and download
+        wallhavenDownloadProcess.wallpaperPath = filePath;
+        wallhavenDownloadProcess.command = [
+            "sh", "-c",
+            "mkdir -p '" + cachePath + "' && curl -s -L -o '" + filePath + "' '" + wallpaperData.path + "'"
+        ];
+        wallhavenDownloadProcess.running = true;
+    }
+
+    function applyWallpaper(path) {
+        ThemeManager.updateAndApplyTheme({
+            "_wallpaper": path,
+            "_enableDynamicWallpapers": false
+        }, true);
+        root.wallpaperSelected(path);
+    }
+
+    Process {
+        id: localWallpapersProcess
+        stdout: StdioCollector {
+            onStreamFinished: {
+                try {
+                    const list = JSON.parse(this.text);
+                    root.localWallpapers = list || [];
+                } catch (e) {
+                    console.error("WallpaperSelector: Failed to parse local wallpapers", e);
+                    root.localWallpapers = [];
+                }
+            }
+        }
+    }
+
+    Process {
+        id: customWallpapersProcess
+        stdout: StdioCollector {
+            onStreamFinished: {
+                try {
+                    const list = JSON.parse(this.text);
+                    root.customWallpapers = list || [];
+                } catch (e) {
+                    console.error("WallpaperSelector: Failed to parse custom wallpapers", e);
+                    root.customWallpapers = [];
+                }
+            }
+        }
+    }
+
+    Process {
+        id: wallhavenProcess
+        stdout: StdioCollector {
+            onStreamFinished: {
+                root.wallhavenLoading = false;
+                try {
+                    const response = JSON.parse(this.text);
+                    if (response.data && Array.isArray(response.data)) {
+                        const newWallpapers = response.data.map(w => ({
+                            id: w.id,
+                            path: w.path,
+                            thumb: w.thumbs.large,
+                            resolution: w.resolution,
+                            file_type: w.file_type,
+                            views: w.views,
+                            favorites: w.favorites
+                        }));
+                        
+                        if (root.wallhavenPage === 1) {
+                            root.wallhavenWallpapers = newWallpapers;
+                        } else {
+                            root.wallhavenWallpapers = root.wallhavenWallpapers.concat(newWallpapers);
+                        }
+
+                        // Check if there are more pages
+                        if (response.meta) {
+                            root.wallhavenHasMore = response.meta.current_page < response.meta.last_page;
+                        }
+                    }
+                } catch (e) {
+                    console.error("WallpaperSelector: Failed to parse Wallhaven response", e);
+                }
+            }
+        }
+    }
+
+    Process {
+        id: wallhavenDownloadProcess
+        property string wallpaperPath: ""
+        
+        onExited: (exitCode, exitStatus) => {
+            if (exitCode === 0 && wallpaperPath !== "") {
+                root.applyWallpaper(wallpaperPath);
+            } else {
+                console.error("WallpaperSelector: Download failed with exit code", exitCode);
+            }
+        }
+    }
+
+    FolderDialog {
+        id: folderDialog
+        title: "Select Wallpapers Folder"
+        onAccepted: {
+            var path = folder.toString().replace("file://", "");
+            root.customFolderPath = path;
+            root.loadCustomWallpapers();
+        }
+    }
+
+    ColumnLayout {
+        anchors.fill: parent
+        spacing: 10
+
+        // Header
+        RowLayout {
+            Layout.fillWidth: true
+            spacing: 12
+
+            Text {
+                text: "󰸉"
+                font.pixelSize: 24
+                font.family: ThemeManager.selectedTheme?.typography?.iconFont || "Material Design Icons"
+                color: ThemeManager.selectedTheme?.colors?.primary || "#fff"
+            }
+
+            ColumnLayout {
+                Layout.fillWidth: true
+                spacing: 2
+
+                Text {
+                    text: qsTr("Wallpaper Selector")
+                    font.pixelSize: 16
+                    font.bold: true
+                    color: ThemeManager.selectedTheme?.colors?.leftMenuFgColorV1 || "#fff"
+                }
+
+                Text {
+                    text: sourceMode === 2 ? qsTr("Browse wallpapers from Wallhaven.cc") : qsTr("Select a wallpaper to apply")
+                    font.pixelSize: 11
+                    color: ThemeManager.selectedTheme?.colors?.subtleText || "#888"
+                }
+            }
+
+            // Settings button (for custom folder)
+            Rectangle {
+                width: 28
+                height: 28
+                radius: 6
+                visible: root.sourceMode === 1
+                color: settingsMouseArea.containsMouse 
+                    ? ThemeManager.selectedTheme?.colors?.primary.alpha(0.2) || "#333"
+                    : "transparent"
+
+                Text {
+                    anchors.centerIn: parent
+                    text: "󰉋"
+                    font.pixelSize: 16
+                    font.family: ThemeManager.selectedTheme?.typography?.iconFont || "Material Design Icons"
+                    color: ThemeManager.selectedTheme?.colors?.subtleText || "#888"
+                }
+
+                MouseArea {
+                    id: settingsMouseArea
+                    anchors.fill: parent
+                    hoverEnabled: true
+                    cursorShape: Qt.PointingHandCursor
+                    onClicked: folderDialog.open()
+                }
+            }
+
+            // Refresh button
+            Rectangle {
+                width: 28
+                height: 28
+                radius: 6
+                color: refreshMouseArea.containsMouse 
+                    ? ThemeManager.selectedTheme?.colors?.primary.alpha(0.2) || "#333"
+                    : "transparent"
+
+                Text {
+                    anchors.centerIn: parent
+                    text: root.wallhavenLoading ? "󰦖" : "󰑐"
+                    font.pixelSize: 16
+                    font.family: ThemeManager.selectedTheme?.typography?.iconFont || "Material Design Icons"
+                    color: ThemeManager.selectedTheme?.colors?.subtleText || "#888"
+
+                    RotationAnimation on rotation {
+                        running: root.wallhavenLoading
+                        from: 0
+                        to: 360
+                        duration: 1000
+                        loops: Animation.Infinite
+                    }
+                }
+
+                MouseArea {
+                    id: refreshMouseArea
+                    anchors.fill: parent
+                    hoverEnabled: true
+                    cursorShape: Qt.PointingHandCursor
+                    onClicked: {
+                        if (root.sourceMode === 0) {
+                            root.loadLocalWallpapers();
+                        } else if (root.sourceMode === 1) {
+                            root.loadCustomWallpapers();
+                        } else {
+                            root.searchWallhaven(true);
+                        }
+                    }
+                }
+            }
+
+            // Close button
+            Rectangle {
+                width: 28
+                height: 28
+                radius: 6
+                color: closeMouseArea.containsMouse 
+                    ? ThemeManager.selectedTheme?.colors?.primary.alpha(0.2) || "#333"
+                    : "transparent"
+
+                Text {
+                    anchors.centerIn: parent
+                    text: "󰅖"
+                    font.pixelSize: 16
+                    font.family: ThemeManager.selectedTheme?.typography?.iconFont || "Material Design Icons"
+                    color: ThemeManager.selectedTheme?.colors?.subtleText || "#888"
+                }
+
+                MouseArea {
+                    id: closeMouseArea
+                    anchors.fill: parent
+                    hoverEnabled: true
+                    cursorShape: Qt.PointingHandCursor
+                    onClicked: root.closeRequested()
+                }
+            }
+        }
+
+        // Source tabs
+        RowLayout {
+            Layout.fillWidth: true
+            spacing: 4
+
+            Repeater {
+                model: root.sourceNames
+
+                Rectangle {
+                    id: tabRect
+                    required property int index
+                    required property string modelData
+                    
+                    Layout.fillWidth: true
+                    height: 32
+                    radius: ThemeManager.selectedTheme?.dimensions?.elementRadius || 8
+                    color: root.sourceMode === tabRect.index
+                        ? ThemeManager.selectedTheme?.colors?.primary.alpha(0.2) || "#333"
+                        : tabMouseArea.containsMouse
+                            ? ThemeManager.selectedTheme?.colors?.primary.alpha(0.1) || "#222"
+                            : "transparent"
+                    border.color: root.sourceMode === tabRect.index
+                        ? ThemeManager.selectedTheme?.colors?.primary || "#6366f1"
+                        : "transparent"
+                    border.width: 1
+
+                    Text {
+                        anchors.centerIn: parent
+                        text: tabRect.modelData
+                        font.pixelSize: 12
+                        font.weight: root.sourceMode === tabRect.index ? Font.Bold : Font.Normal
+                        color: root.sourceMode === tabRect.index
+                            ? ThemeManager.selectedTheme?.colors?.primary || "#6366f1"
+                            : ThemeManager.selectedTheme?.colors?.leftMenuFgColorV1 || "#fff"
+                    }
+
+                    MouseArea {
+                        id: tabMouseArea
+                        anchors.fill: parent
+                        hoverEnabled: true
+                        cursorShape: Qt.PointingHandCursor
+                        onClicked: {
+                            root.sourceMode = tabRect.index;
+                            if (tabRect.index === 2 && root.wallhavenWallpapers.length === 0) {
+                                root.searchWallhaven(true);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // Search bar
+        RowLayout {
+            Layout.fillWidth: true
+            spacing: 8
+
+            EditableField {
+                id: searchField
+                Layout.fillWidth: true
+                Layout.preferredHeight: 36
+
+                placeholderText: root.sourceMode === 2 
+                    ? qsTr("Search Wallhaven (e.g. nature, anime, abstract)...")
+                    : qsTr("Filter wallpapers...")
+                font.pixelSize: 13
+                horizontalAlignment: Text.AlignLeft
+
+                normalBackground: ThemeManager.selectedTheme?.colors?.leftMenuBgColorV2 || "#222"
+                normalForeground: ThemeManager.selectedTheme?.colors?.leftMenuFgColorV1 || "#fff"
+                focusedBorderColor: ThemeManager.selectedTheme?.colors?.primary || "#6366f1"
+                borderColor: ThemeManager.selectedTheme?.colors?.primary.alpha(0.3) || "#444"
+                borderSize: 1
+
+                topLeftRadius: ThemeManager.selectedTheme?.dimensions?.elementRadius || 8
+                topRightRadius: ThemeManager.selectedTheme?.dimensions?.elementRadius || 8
+                bottomLeftRadius: ThemeManager.selectedTheme?.dimensions?.elementRadius || 8
+                bottomRightRadius: ThemeManager.selectedTheme?.dimensions?.elementRadius || 8
+
+                onTextChanged: {
+                    if (root.sourceMode === 2) {
+                        root.wallhavenQuery = text;
+                    } else {
+                        root.filterText = text;
+                    }
+                }
+
+                onAccepted: {
+                    if (root.sourceMode === 2) {
+                        root.searchWallhaven(true);
+                    }
+                }
+            }
+
+            // Search button for Wallhaven
+            Rectangle {
+                Layout.preferredWidth: 36
+                Layout.preferredHeight: 36
+                radius: ThemeManager.selectedTheme?.dimensions?.elementRadius || 8
+                visible: root.sourceMode === 2
+                color: searchBtnMouse.containsMouse
+                    ? ThemeManager.selectedTheme?.colors?.primary || "#6366f1"
+                    : ThemeManager.selectedTheme?.colors?.primary.alpha(0.8) || "#5558e8"
+
+                Text {
+                    anchors.centerIn: parent
+                    text: "󰍉"
+                    font.pixelSize: 16
+                    font.family: ThemeManager.selectedTheme?.typography?.iconFont || "Material Design Icons"
+                    color: "#fff"
+                }
+
+                MouseArea {
+                    id: searchBtnMouse
+                    anchors.fill: parent
+                    hoverEnabled: true
+                    cursorShape: Qt.PointingHandCursor
+                    onClicked: root.searchWallhaven(true)
+                }
+            }
+        }
+
+        // Wallhaven filters (only when Wallhaven is selected)
+        Flow {
+            Layout.fillWidth: true
+            spacing: 6
+            visible: root.sourceMode === 2
+
+            // Sorting dropdown with order and topRange
+            Rectangle {
+                id: sortingBtn
+                width: sortingText.width + 16
+                height: 28
+                radius: 6
+                color: ThemeManager.selectedTheme?.colors?.leftMenuBgColorV2 || "#222"
+
+                Text {
+                    id: sortingText
+                    anchors.centerIn: parent
+                    text: {
+                        const sorts = { "toplist": "Top", "date_added": "New", "random": "Random", "views": "Views", "relevance": "Relevant", "favorites": "Fav" };
+                        let label = sorts[root.wallhavenSorting] || "Top";
+                        if (root.wallhavenSorting === "toplist") {
+                            const range = root.topRangePresets.find(r => r.value === root.wallhavenTopRange);
+                            label += " (" + (range ? range.name : root.wallhavenTopRange) + ")";
+                        }
+                        label += root.wallhavenOrder === "asc" ? " ↑" : " ↓";
+                        return label;
+                    }
+                    font.pixelSize: 11
+                    color: ThemeManager.selectedTheme?.colors?.leftMenuFgColorV1 || "#fff"
+                }
+
+                MouseArea {
+                    anchors.fill: parent
+                    cursorShape: Qt.PointingHandCursor
+                    onClicked: sortingPopup.visible ? sortingPopup.close() : sortingPopup.open()
+                }
+
+                Popup {
+                    id: sortingPopup
+                    x: 0
+                    y: -height - 4
+                    width: 180
+                    padding: 8
+                    closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
+
+                    background: Rectangle {
+                        color: ThemeManager.selectedTheme?.colors?.leftMenuBgColorV1 || "#1a1a2e"
+                        radius: 8
+                        border.color: ThemeManager.selectedTheme?.colors?.primary.alpha(0.3) || "#444"
+                        border.width: 1
+                    }
+
+                    contentItem: Column {
+                        spacing: 6
+
+                        // Sort + Order in one row each
+                        Grid {
+                            columns: 3
+                            spacing: 4
+
+                            Repeater {
+                                model: [
+                                    { name: "Top", value: "toplist" },
+                                    { name: "New", value: "date_added" },
+                                    { name: "Random", value: "random" },
+                                    { name: "Views", value: "views" },
+                                    { name: "Fav", value: "favorites" },
+                                    { name: "Relevant", value: "relevance" }
+                                ]
+
+                                Rectangle {
+                                    id: sortOptionRect
+                                    required property var modelData
+                                    width: 52
+                                    height: 26
+                                    radius: 4
+                                    color: root.wallhavenSorting === sortOptionRect.modelData.value
+                                        ? ThemeManager.selectedTheme?.colors?.primary.alpha(0.3) || "#333"
+                                        : ThemeManager.selectedTheme?.colors?.leftMenuBgColorV2 || "#222"
+                                    border.color: root.wallhavenSorting === sortOptionRect.modelData.value
+                                        ? ThemeManager.selectedTheme?.colors?.primary || "#6366f1"
+                                        : "transparent"
+                                    border.width: 1
+
+                                    Text {
+                                        anchors.centerIn: parent
+                                        text: sortOptionRect.modelData.name
+                                        font.pixelSize: 10
+                                        color: root.wallhavenSorting === sortOptionRect.modelData.value
+                                            ? ThemeManager.selectedTheme?.colors?.primary || "#6366f1"
+                                            : ThemeManager.selectedTheme?.colors?.leftMenuFgColorV1 || "#fff"
+                                    }
+
+                                    MouseArea {
+                                        anchors.fill: parent
+                                        cursorShape: Qt.PointingHandCursor
+                                        onClicked: {
+                                            root.wallhavenSorting = sortOptionRect.modelData.value;
+                                            root.searchWallhaven(true);
+                                        }
+                                    }
+                                }
+                            }
+                        }
+
+                        // Order row
+                        Row {
+                            spacing: 4
+
+                            Repeater {
+                                model: [
+                                    { name: "Desc ↓", value: "desc" },
+                                    { name: "Asc ↑", value: "asc" }
+                                ]
+
+                                Rectangle {
+                                    id: orderRect
+                                    required property var modelData
+                                    width: 80
+                                    height: 26
+                                    radius: 4
+                                    color: root.wallhavenOrder === orderRect.modelData.value
+                                        ? ThemeManager.selectedTheme?.colors?.primary.alpha(0.3) || "#333"
+                                        : ThemeManager.selectedTheme?.colors?.leftMenuBgColorV2 || "#222"
+                                    border.color: root.wallhavenOrder === orderRect.modelData.value
+                                        ? ThemeManager.selectedTheme?.colors?.primary || "#6366f1"
+                                        : "transparent"
+                                    border.width: 1
+
+                                    Text {
+                                        anchors.centerIn: parent
+                                        text: orderRect.modelData.name
+                                        font.pixelSize: 10
+                                        color: root.wallhavenOrder === orderRect.modelData.value
+                                            ? ThemeManager.selectedTheme?.colors?.primary || "#6366f1"
+                                            : ThemeManager.selectedTheme?.colors?.leftMenuFgColorV1 || "#fff"
+                                    }
+
+                                    MouseArea {
+                                        anchors.fill: parent
+                                        cursorShape: Qt.PointingHandCursor
+                                        onClicked: {
+                                            root.wallhavenOrder = orderRect.modelData.value;
+                                            root.searchWallhaven(true);
+                                        }
+                                    }
+                                }
+                            }
+                        }
+
+                        // Time Range (only for toplist)
+                        Column {
+                            spacing: 4
+                            visible: root.wallhavenSorting === "toplist"
+
+                            Rectangle {
+                                width: 164
+                                height: 1
+                                color: ThemeManager.selectedTheme?.colors?.primary.alpha(0.2) || "#333"
+                            }
+
+                            Text {
+                                text: "Time Range"
+                                font.pixelSize: 9
+                                color: ThemeManager.selectedTheme?.colors?.subtleText || "#888"
+                            }
+
+                            Grid {
+                                columns: 2
+                                spacing: 4
+
+                                Repeater {
+                                    model: root.topRangePresets
+
+                                    Rectangle {
+                                        id: rangeRect
+                                        required property var modelData
+                                        width: 78
+                                        height: 24
+                                        radius: 4
+                                        color: root.wallhavenTopRange === rangeRect.modelData.value
+                                            ? ThemeManager.selectedTheme?.colors?.primary.alpha(0.3) || "#333"
+                                            : ThemeManager.selectedTheme?.colors?.leftMenuBgColorV2 || "#222"
+                                        border.color: root.wallhavenTopRange === rangeRect.modelData.value
+                                            ? ThemeManager.selectedTheme?.colors?.primary || "#6366f1"
+                                            : "transparent"
+                                        border.width: 1
+
+                                        Text {
+                                            anchors.centerIn: parent
+                                            text: rangeRect.modelData.name
+                                            font.pixelSize: 10
+                                            color: root.wallhavenTopRange === rangeRect.modelData.value
+                                                ? ThemeManager.selectedTheme?.colors?.primary || "#6366f1"
+                                                : ThemeManager.selectedTheme?.colors?.leftMenuFgColorV1 || "#fff"
+                                        }
+
+                                        MouseArea {
+                                            anchors.fill: parent
+                                            cursorShape: Qt.PointingHandCursor
+                                            onClicked: {
+                                                root.wallhavenTopRange = rangeRect.modelData.value;
+                                                root.searchWallhaven(true);
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Categories dropdown
+            Rectangle {
+                id: categoriesBtn
+                width: catBtnText.width + 16
+                height: 28
+                radius: 6
+                color: ThemeManager.selectedTheme?.colors?.leftMenuBgColorV2 || "#222"
+
+                Text {
+                    id: catBtnText
+                    anchors.centerIn: parent
+                    text: "Categories"
+                    font.pixelSize: 11
+                    color: ThemeManager.selectedTheme?.colors?.leftMenuFgColorV1 || "#fff"
+                }
+
+                MouseArea {
+                    anchors.fill: parent
+                    cursorShape: Qt.PointingHandCursor
+                    onClicked: categoriesPopup.visible ? categoriesPopup.close() : categoriesPopup.open()
+                }
+
+                Popup {
+                    id: categoriesPopup
+                    x: 0
+                    y: -height - 4
+                    padding: 8
+                    closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
+
+                    background: Rectangle {
+                        color: ThemeManager.selectedTheme?.colors?.leftMenuBgColorV1 || "#1a1a2e"
+                        radius: 8
+                        border.color: ThemeManager.selectedTheme?.colors?.primary.alpha(0.3) || "#444"
+                        border.width: 1
+                    }
+
+                    contentItem: Column {
+                        spacing: 4
+
+                        Repeater {
+                            model: [
+                                { label: "General", mask: 0 },
+                                { label: "Anime", mask: 1 },
+                                { label: "People", mask: 2 }
+                            ]
+
+                            Rectangle {
+                                id: catPopupRect
+                                required property var modelData
+                                property bool isOn: root.wallhavenCategory.charAt(catPopupRect.modelData.mask) === "1"
+                                
+                                width: 100
+                                height: 28
+                                radius: 4
+                                color: catPopupRect.isOn
+                                    ? ThemeManager.selectedTheme?.colors?.primary.alpha(0.3) || "#333"
+                                    : ThemeManager.selectedTheme?.colors?.leftMenuBgColorV2 || "#222"
+                                border.color: catPopupRect.isOn
+                                    ? ThemeManager.selectedTheme?.colors?.primary || "#6366f1"
+                                    : "transparent"
+                                border.width: 1
+
+                                Row {
+                                    anchors.centerIn: parent
+                                    spacing: 6
+
+                                    Rectangle {
+                                        width: 14
+                                        height: 14
+                                        radius: 3
+                                        anchors.verticalCenter: parent.verticalCenter
+                                        color: catPopupRect.isOn 
+                                            ? ThemeManager.selectedTheme?.colors?.primary || "#6366f1"
+                                            : "transparent"
+                                        border.color: ThemeManager.selectedTheme?.colors?.primary || "#6366f1"
+                                        border.width: 1
+
+                                        Text {
+                                            anchors.centerIn: parent
+                                            text: catPopupRect.isOn ? "✓" : ""
+                                            font.pixelSize: 10
+                                            color: "#fff"
+                                        }
+                                    }
+
+                                    Text {
+                                        text: catPopupRect.modelData.label
+                                        font.pixelSize: 11
+                                        anchors.verticalCenter: parent.verticalCenter
+                                        color: catPopupRect.isOn
+                                            ? ThemeManager.selectedTheme?.colors?.primary || "#6366f1"
+                                            : ThemeManager.selectedTheme?.colors?.leftMenuFgColorV1 || "#fff"
+                                    }
+                                }
+
+                                MouseArea {
+                                    anchors.fill: parent
+                                    cursorShape: Qt.PointingHandCursor
+                                    onClicked: {
+                                        let cats = root.wallhavenCategory.split("");
+                                        cats[catPopupRect.modelData.mask] = cats[catPopupRect.modelData.mask] === "1" ? "0" : "1";
+                                        if (cats.join("") !== "000") {
+                                            root.wallhavenCategory = cats.join("");
+                                            root.searchWallhaven(true);
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Color filter
+            Rectangle {
+                id: colorFilterBtn
+                height: 28
+                width: colorFilterRow.width + 12
+                radius: 6
+                color: ThemeManager.selectedTheme?.colors?.leftMenuBgColorV2 || "#222"
+                border.color: root.wallhavenColor !== "" ? ThemeManager.selectedTheme?.colors?.primary || "#6366f1" : "transparent"
+                border.width: 1
+
+                Row {
+                    id: colorFilterRow
+                    anchors.centerIn: parent
+                    spacing: 4
+
+                    Rectangle {
+                        width: 14
+                        height: 14
+                        radius: 7
+                        anchors.verticalCenter: parent.verticalCenter
+                        color: root.wallhavenColor !== "" ? ("#" + root.wallhavenColor) : "transparent"
+                        border.color: root.wallhavenColor === "" 
+                            ? ThemeManager.selectedTheme?.colors?.subtleText || "#666" 
+                            : "transparent"
+                        border.width: 1
+
+                        Text {
+                            anchors.centerIn: parent
+                            text: root.wallhavenColor === "" ? "?" : ""
+                            font.pixelSize: 9
+                            color: ThemeManager.selectedTheme?.colors?.subtleText || "#888"
+                        }
+                    }
+
+                    Text {
+                        text: root.wallhavenColor === "" ? "Color" : root.colorPresets.find(c => c.hex === root.wallhavenColor)?.name || "Custom"
+                        font.pixelSize: 11
+                        anchors.verticalCenter: parent.verticalCenter
+                        color: root.wallhavenColor !== ""
+                            ? ThemeManager.selectedTheme?.colors?.primary || "#6366f1"
+                            : ThemeManager.selectedTheme?.colors?.subtleText || "#888"
+                    }
+                }
+
+                MouseArea {
+                    anchors.fill: parent
+                    cursorShape: Qt.PointingHandCursor
+                    onClicked: colorPopup.open()
+                }
+
+                Popup {
+                    id: colorPopup
+                    x: 0
+                    y: parent.height + 4
+                    width: 220
+                    padding: 8
+
+                    background: Rectangle {
+                        color: ThemeManager.selectedTheme?.colors?.leftMenuBgColorV1 || "#1a1a2e"
+                        radius: 8
+                        border.color: ThemeManager.selectedTheme?.colors?.primary.alpha(0.3) || "#444"
+                        border.width: 1
+                    }
+
+                    contentItem: Grid {
+                        columns: 6
+                        spacing: 4
+
+                        Repeater {
+                            model: root.colorPresets
+
+                            Rectangle {
+                                id: colorPresetRect
+                                required property var modelData
+                                required property int index
+
+                                width: 32
+                                height: 24
+                                radius: 4
+                                color: colorPresetRect.modelData.hex === "" 
+                                    ? ThemeManager.selectedTheme?.colors?.leftMenuBgColorV2 || "#333"
+                                    : ("#" + colorPresetRect.modelData.hex)
+                                border.color: root.wallhavenColor === colorPresetRect.modelData.hex
+                                    ? ThemeManager.selectedTheme?.colors?.primary || "#6366f1"
+                                    : (colorPresetRect.modelData.hex === "ffffff" || colorPresetRect.modelData.hex === "cccccc" ? "#999" : "transparent")
+                                border.width: root.wallhavenColor === colorPresetRect.modelData.hex ? 2 : 1
+
+                                Text {
+                                    anchors.centerIn: parent
+                                    text: colorPresetRect.modelData.hex === "" ? "✕" : ""
+                                    font.pixelSize: 12
+                                    color: ThemeManager.selectedTheme?.colors?.subtleText || "#888"
+                                }
+
+                                MouseArea {
+                                    anchors.fill: parent
+                                    cursorShape: Qt.PointingHandCursor
+                                    hoverEnabled: true
+                                    onClicked: {
+                                        root.wallhavenColor = colorPresetRect.modelData.hex;
+                                        colorPopup.close();
+                                        root.searchWallhaven(true);
+                                    }
+                                }
+
+                                ToolTip.visible: colorPresetMouse.containsMouse
+                                ToolTip.text: colorPresetRect.modelData.name
+                                ToolTip.delay: 500
+
+                                MouseArea {
+                                    id: colorPresetMouse
+                                    anchors.fill: parent
+                                    hoverEnabled: true
+                                    cursorShape: Qt.PointingHandCursor
+                                    onClicked: {
+                                        root.wallhavenColor = colorPresetRect.modelData.hex;
+                                        colorPopup.close();
+                                        root.searchWallhaven(true);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Resolution filter
+            Rectangle {
+                id: resFilterBtn
+                height: 28
+                width: resFilterText.width + 12
+                radius: 6
+                color: ThemeManager.selectedTheme?.colors?.leftMenuBgColorV2 || "#222"
+                border.color: root.wallhavenResolution !== "" ? ThemeManager.selectedTheme?.colors?.primary || "#6366f1" : "transparent"
+                border.width: 1
+
+                Text {
+                    id: resFilterText
+                    anchors.centerIn: parent
+                    text: root.wallhavenResolution === "" ? "Resolution" : root.resolutionPresets.find(r => r.value === root.wallhavenResolution)?.name || root.wallhavenResolution
+                    font.pixelSize: 11
+                    color: root.wallhavenResolution !== ""
+                        ? ThemeManager.selectedTheme?.colors?.primary || "#6366f1"
+                        : ThemeManager.selectedTheme?.colors?.subtleText || "#888"
+                }
+
+                MouseArea {
+                    anchors.fill: parent
+                    cursorShape: Qt.PointingHandCursor
+                    onClicked: resPopup.open()
+                }
+
+                Popup {
+                    id: resPopup
+                    x: 0
+                    y: parent.height + 4
+                    width: 120
+                    padding: 8
+
+                    background: Rectangle {
+                        color: ThemeManager.selectedTheme?.colors?.leftMenuBgColorV1 || "#1a1a2e"
+                        radius: 8
+                        border.color: ThemeManager.selectedTheme?.colors?.primary.alpha(0.3) || "#444"
+                        border.width: 1
+                    }
+
+                    contentItem: Column {
+                        spacing: 4
+
+                        Repeater {
+                            model: root.resolutionPresets
+
+                            Rectangle {
+                                id: resPresetRect
+                                required property var modelData
+                                required property int index
+
+                                width: 104
+                                height: 28
+                                radius: 6
+                                color: root.wallhavenResolution === resPresetRect.modelData.value
+                                    ? ThemeManager.selectedTheme?.colors?.primary.alpha(0.2) || "#333"
+                                    : resPresetMouse.containsMouse
+                                        ? ThemeManager.selectedTheme?.colors?.primary.alpha(0.1) || "#222"
+                                        : "transparent"
+                                border.color: root.wallhavenResolution === resPresetRect.modelData.value
+                                    ? ThemeManager.selectedTheme?.colors?.primary || "#6366f1"
+                                    : "transparent"
+                                border.width: 1
+
+                                Text {
+                                    anchors.centerIn: parent
+                                    text: resPresetRect.modelData.name + (resPresetRect.modelData.value !== "" ? "+" : "")
+                                    font.pixelSize: 11
+                                    color: root.wallhavenResolution === resPresetRect.modelData.value
+                                        ? ThemeManager.selectedTheme?.colors?.primary || "#6366f1"
+                                        : ThemeManager.selectedTheme?.colors?.leftMenuFgColorV1 || "#fff"
+                                }
+
+                                MouseArea {
+                                    id: resPresetMouse
+                                    anchors.fill: parent
+                                    hoverEnabled: true
+                                    cursorShape: Qt.PointingHandCursor
+                                    onClicked: {
+                                        root.wallhavenResolution = resPresetRect.modelData.value;
+                                        resPopup.close();
+                                        root.searchWallhaven(true);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // Wallpaper Grid
+        Rectangle {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            radius: ThemeManager.selectedTheme?.dimensions?.elementRadius || 8
+            color: ThemeManager.selectedTheme?.colors?.leftMenuBgColorV2 || "#1a1a2e"
+            clip: true
+
+            GridView {
+                id: wallpaperGrid
+                anchors.fill: parent
+                anchors.margins: 8
+
+                property int columns: root.compact ? 1 : 4
+                cellWidth: (width - 16) / columns
+                cellHeight: root.compact ? cellWidth * 0.5 + 24 : cellWidth * 0.6 + 28
+
+                model: root.filteredWallpapers
+                clip: true
+                boundsBehavior: Flickable.StopAtBounds
+
+                ScrollBar.vertical: ScrollBar {
+                    active: true
+                    policy: ScrollBar.AsNeeded
+                }
+
+                onAtYEndChanged: {
+                    if (atYEnd && root.sourceMode === 2 && !root.wallhavenLoading && root.wallhavenHasMore) {
+                        root.loadMoreWallhaven();
+                    }
+                }
+
+                delegate: Item {
+                    id: wallpaperDelegate
+                    required property int index
+                    required property var modelData
+
+                    width: wallpaperGrid.cellWidth
+                    height: wallpaperGrid.cellHeight
+
+                    property bool isWallhaven: root.sourceMode === 2
+                    property string thumbUrl: isWallhaven ? modelData.thumb : ("file://" + modelData)
+                    property string wallpaperPath: isWallhaven ? modelData.path : modelData
+                    property string displayName: isWallhaven 
+                        ? (modelData.resolution || modelData.id)
+                        : modelData.split('/').pop()
+
+                    Rectangle {
+                        id: cardBg
+                        anchors.fill: parent
+                        anchors.margins: 4
+                        radius: ThemeManager.selectedTheme?.dimensions?.elementRadius || 8
+                        color: itemMouseArea.containsMouse 
+                            ? ThemeManager.selectedTheme?.colors?.primary.alpha(0.15) || "#333"
+                            : "transparent"
+                        border.color: ThemeManager.currentWallpaper === wallpaperDelegate.wallpaperPath
+                            ? ThemeManager.selectedTheme?.colors?.primary || "#6366f1"
+                            : itemMouseArea.containsMouse 
+                                ? ThemeManager.selectedTheme?.colors?.primary.alpha(0.5) || "#555"
+                                : "transparent"
+                        border.width: ThemeManager.currentWallpaper === wallpaperDelegate.wallpaperPath ? 2 : 1
+
+                        Behavior on color {
+                            ColorAnimation { duration: 150 }
+                        }
+
+                        ColumnLayout {
+                            anchors.fill: parent
+                            anchors.margins: 4
+                            spacing: 4
+
+                            Rectangle {
+                                Layout.fillWidth: true
+                                Layout.fillHeight: true
+                                radius: (ThemeManager.selectedTheme?.dimensions?.elementRadius || 8) - 2
+                                color: ThemeManager.selectedTheme?.colors?.leftMenuBgColorV1 || "#111"
+                                clip: true
+
+                                Image {
+                                    id: thumbImage
+                                    anchors.fill: parent
+                                    source: wallpaperDelegate.thumbUrl
+                                    fillMode: Image.PreserveAspectCrop
+                                    asynchronous: true
+                                    sourceSize: Qt.size(300, 200)
+                                }
+
+                                // Loading indicator
+                                Rectangle {
+                                    anchors.centerIn: parent
+                                    width: 24
+                                    height: 24
+                                    radius: 12
+                                    color: ThemeManager.selectedTheme?.colors?.primary.alpha(0.3) || "#333"
+                                    visible: thumbImage.status === Image.Loading
+
+                                    Text {
+                                        anchors.centerIn: parent
+                                        text: "󰑐"
+                                        font.pixelSize: 14
+                                        font.family: ThemeManager.selectedTheme?.typography?.iconFont || "Material Design Icons"
+                                        color: ThemeManager.selectedTheme?.colors?.primary || "#6366f1"
+
+                                        RotationAnimation on rotation {
+                                            running: thumbImage.status === Image.Loading
+                                            from: 0
+                                            to: 360
+                                            duration: 1000
+                                            loops: Animation.Infinite
+                                        }
+                                    }
+                                }
+
+                                // Wallhaven badge
+                                Rectangle {
+                                    anchors.top: parent.top
+                                    anchors.left: parent.left
+                                    anchors.margins: 4
+                                    height: 16
+                                    width: favText.width + 8
+                                    radius: 4
+                                    color: "#000000aa"
+                                    visible: wallpaperDelegate.isWallhaven && modelData.favorites > 0
+
+                                    Text {
+                                        id: favText
+                                        anchors.centerIn: parent
+                                        text: "♥ " + modelData.favorites
+                                        font.pixelSize: 9
+                                        color: "#ff6b6b"
+                                    }
+                                }
+                            }
+
+                            Text {
+                                Layout.fillWidth: true
+                                text: wallpaperDelegate.displayName
+                                font.pixelSize: 10
+                                color: ThemeManager.selectedTheme?.colors?.subtleText || "#888"
+                                elide: Text.ElideMiddle
+                                horizontalAlignment: Text.AlignHCenter
+                            }
+                        }
+
+                        MouseArea {
+                            id: itemMouseArea
+                            anchors.fill: parent
+                            hoverEnabled: true
+                            cursorShape: Qt.PointingHandCursor
+                            onClicked: root.selectWallpaper(wallpaperDelegate.modelData)
+                        }
+                    }
+                }
+
+                // Empty state
+                Text {
+                    anchors.centerIn: parent
+                    visible: root.filteredWallpapers.length === 0 && !root.wallhavenLoading
+                    text: {
+                        if (root.sourceMode === 2) {
+                            return qsTr("Search for wallpapers or click refresh to load top wallpapers");
+                        }
+                        if (root.sourceMode === 1 && root.customFolderPath === "") {
+                            return qsTr("No custom folder selected.\nClick the folder icon to choose a folder.");
+                        }
+                        return qsTr("No wallpapers found");
+                    }
+                    font.pixelSize: 14
+                    color: ThemeManager.selectedTheme?.colors?.subtleText || "#888"
+                    horizontalAlignment: Text.AlignHCenter
+                }
+
+                // Loading state for Wallhaven
+                Rectangle {
+                    anchors.centerIn: parent
+                    width: 48
+                    height: 48
+                    radius: 24
+                    color: ThemeManager.selectedTheme?.colors?.primary.alpha(0.2) || "#333"
+                    visible: root.wallhavenLoading && root.wallhavenWallpapers.length === 0
+
+                    Text {
+                        anchors.centerIn: parent
+                        text: "󰑐"
+                        font.pixelSize: 24
+                        font.family: ThemeManager.selectedTheme?.typography?.iconFont || "Material Design Icons"
+                        color: ThemeManager.selectedTheme?.colors?.primary || "#6366f1"
+
+                        RotationAnimation on rotation {
+                            running: root.wallhavenLoading
+                            from: 0
+                            to: 360
+                            duration: 1000
+                            loops: Animation.Infinite
+                        }
+                    }
+                }
+            }
+
+            // Load more indicator
+            Rectangle {
+                anchors.bottom: parent.bottom
+                anchors.horizontalCenter: parent.horizontalCenter
+                anchors.bottomMargin: 8
+                width: loadMoreText.width + 24
+                height: 28
+                radius: 14
+                color: ThemeManager.selectedTheme?.colors?.primary.alpha(0.9) || "#6366f1"
+                visible: root.sourceMode === 2 && root.wallhavenLoading && root.wallhavenWallpapers.length > 0
+
+                Text {
+                    id: loadMoreText
+                    anchors.centerIn: parent
+                    text: "Loading more..."
+                    font.pixelSize: 11
+                    color: "#fff"
+                }
+            }
+        }
+    }
+}

--- a/config/quickshell/components/WallpaperSelector.qml
+++ b/config/quickshell/components/WallpaperSelector.qml
@@ -2,15 +2,11 @@
 pragma ComponentBehavior: Bound
 
 import QtQuick
-import QtQuick.Controls
 import QtQuick.Layouts
-import Quickshell
-import Quickshell.Io
 
 import "root:/themes"
-import "root:/components"
 import "root:/config"
-import "root:/utils"
+import "root:/components/wallpaper_selector"
 
 Item {
     id: root
@@ -24,88 +20,27 @@ Item {
         onClicked: event => event.accepted = true
     }
 
-    property bool compact: width < 400 // For sidebar use
-    property bool applyToAllMonitors: true
+    property bool compact: width < 400
+    property int sourceMode: 0 // 0 = Local, 1 = Downloaded, 2 = Wallhaven
     property string filterText: ""
-    property int sourceMode: 0 // 0 = Local, 1 = Custom, 2 = Wallhaven
 
-    property var localWallpapers: []
-    property var downloadedWallpapers: []
+    // Read wallpaper lists from ThemeManager
+    property var localWallpapers: ThemeManager.localWallpapers
+    property var downloadedWallpapers: ThemeManager.downloadedWallpapers
     property var wallhavenWallpapers: []
-    property string downloadedFolderPath: App.cacheFolderPath + "/wallpapers"
 
     // Wallhaven settings
     property string wallhavenQuery: ""
-    property string wallhavenCategory: "110" // General + Anime (no People)
-    property string wallhavenPurity: "100"   // sfw only
+    property string wallhavenCategory: "110"
+    property string wallhavenPurity: "100"
     property string wallhavenSorting: "toplist"
-    property string wallhavenOrder: "desc" // desc or asc
+    property string wallhavenOrder: "desc"
     property string wallhavenTopRange: "1M"
-    property string wallhavenColor: "" // Color filter (hex without #)
+    property string wallhavenColor: ""
+    property string wallhavenResolution: ""
     property int wallhavenPage: 1
     property bool wallhavenLoading: false
     property bool wallhavenHasMore: true
-
-    // Top range presets
-    property var topRangePresets: [
-        { name: "Day", value: "1d" },
-        { name: "3 Days", value: "3d" },
-        { name: "Week", value: "1w" },
-        { name: "Month", value: "1M" },
-        { name: "3 Months", value: "3M" },
-        { name: "6 Months", value: "6M" },
-        { name: "1 Year", value: "1y" }
-    ]
-
-    // Wallhaven color palette
-    property var colorPresets: [
-        { name: "Any", hex: "" },
-        { name: "Lonestar", hex: "660000" },
-        { name: "Red Berry", hex: "990000" },
-        { name: "Guardsman Red", hex: "cc0000" },
-        { name: "Persian Red", hex: "cc3333" },
-        { name: "French Rose", hex: "ea4c88" },
-        { name: "Plum", hex: "993399" },
-        { name: "Royal Purple", hex: "663399" },
-        { name: "Sapphire", hex: "333399" },
-        { name: "Science Blue", hex: "0066cc" },
-        { name: "Pacific Blue", hex: "0099cc" },
-        { name: "Downy", hex: "66cccc" },
-        { name: "Atlantis", hex: "77cc33" },
-        { name: "Limeade", hex: "669900" },
-        { name: "Verdun Green", hex: "336600" },
-        { name: "Verdun Green 2", hex: "666600" },
-        { name: "Olive", hex: "999900" },
-        { name: "Earls Green", hex: "cccc33" },
-        { name: "Yellow", hex: "ffff00" },
-        { name: "Sunglow", hex: "ffcc33" },
-        { name: "Orange Peel", hex: "ff9900" },
-        { name: "Blaze Orange", hex: "ff6600" },
-        { name: "Tuscany", hex: "cc6633" },
-        { name: "Potters Clay", hex: "996633" },
-        { name: "Nutmeg", hex: "663300" },
-        { name: "Black", hex: "000000" },
-        { name: "Dusty Gray", hex: "999999" },
-        { name: "Silver", hex: "cccccc" },
-        { name: "White", hex: "ffffff" },
-        { name: "Gun Powder", hex: "424153" }
-    ]
-
-    // Resolution filter
-    property string wallhavenResolution: "" // atleast resolution (e.g. "1920x1080")
-    property var resolutionPresets: [
-        { name: "Any", value: "" },
-        { name: "HD", value: "1280x720" },
-        { name: "FHD", value: "1920x1080" },
-        { name: "2K", value: "2560x1440" },
-        { name: "4K", value: "3840x2160" },
-        { name: "5K", value: "5120x2880" },
-        { name: "8K", value: "7680x4320" },
-        { name: "UW FHD", value: "2560x1080" },
-        { name: "UW QHD", value: "3440x1440" }
-    ]
-
-    property var sourceNames: ["Local", "Downloaded", "Wallhaven"]
 
     property var currentWallpapers: {
         if (sourceMode === 0) return localWallpapers;
@@ -114,7 +49,7 @@ Item {
     }
 
     property var filteredWallpapers: {
-        if (sourceMode === 2) return currentWallpapers; // Wallhaven uses API search
+        if (sourceMode === 2) return currentWallpapers;
         if (!currentWallpapers || currentWallpapers.length === 0) return [];
         if (filterText === "") return currentWallpapers;
 
@@ -126,18 +61,7 @@ Item {
     }
 
     Component.onCompleted: {
-        loadLocalWallpapers();
-        loadDownloadedWallpapers();
-    }
-
-    function loadLocalWallpapers() {
-        localWallpapersProcess.command = Helper.getWallpapersList(App.wallpapersPath);
-        localWallpapersProcess.running = true;
-    }
-
-    function loadDownloadedWallpapers() {
-        downloadedWallpapersProcess.command = Helper.getWallpapersList(downloadedFolderPath);
-        downloadedWallpapersProcess.running = true;
+        ThemeManager.refreshAllWallpaperLists();
     }
 
     function searchWallhaven(resetPage) {
@@ -149,8 +73,6 @@ Item {
             wallhavenHasMore = true;
         }
 
-        wallhavenLoading = true;
-        
         let url = "https://wallhaven.cc/api/v1/search?";
         url += "categories=" + wallhavenCategory;
         url += "&purity=" + wallhavenPurity;
@@ -160,23 +82,18 @@ Item {
         if (wallhavenSorting === "toplist") {
             url += "&topRange=" + wallhavenTopRange;
         }
-        
         if (wallhavenQuery !== "") {
             url += "&q=" + encodeURIComponent(wallhavenQuery);
         }
-
         if (wallhavenColor !== "") {
             url += "&colors=" + wallhavenColor;
         }
-
         if (wallhavenResolution !== "") {
             url += "&atleast=" + wallhavenResolution;
         }
-        
         url += "&page=" + wallhavenPage;
 
-        wallhavenProcess.command = ["curl", "-s", url];
-        wallhavenProcess.running = true;
+        ThemeManager.searchWallhaven(url);
     }
 
     function loadMoreWallhaven() {
@@ -186,35 +103,14 @@ Item {
     }
 
     function selectWallpaper(wallpaperData) {
-        let path = "";
-        
         if (sourceMode === 2) {
-            // Wallhaven - need to download first
             if (typeof wallpaperData === 'object') {
-                path = wallpaperData.path;
-                // Download to cache folder
-                downloadWallhaven(wallpaperData);
+                ThemeManager.downloadWallhaven(wallpaperData.id, wallpaperData.file_type, wallpaperData.path);
                 return;
             }
-        } else {
-            path = typeof wallpaperData === 'string' ? wallpaperData : wallpaperData.path;
         }
-
+        const path = typeof wallpaperData === 'string' ? wallpaperData : wallpaperData.path;
         applyWallpaper(path);
-    }
-
-    function downloadWallhaven(wallpaperData) {
-        const filename = wallpaperData.id + "." + wallpaperData.file_type.split('/')[1];
-        const cachePath = App.cacheFolderPath + "/wallpapers";
-        const filePath = cachePath + "/" + filename;
-
-        // Create cache dir and download
-        wallhavenDownloadProcess.wallpaperPath = filePath;
-        wallhavenDownloadProcess.command = [
-            "sh", "-c",
-            "mkdir -p '" + cachePath + "' && curl -s -L -o '" + filePath + "' '" + wallpaperData.path + "'"
-        ];
-        wallhavenDownloadProcess.running = true;
     }
 
     function applyWallpaper(path) {
@@ -225,84 +121,60 @@ Item {
         root.wallpaperSelected(path);
     }
 
-    Process {
-        id: localWallpapersProcess
-        stdout: StdioCollector {
-            onStreamFinished: {
-                try {
-                    const list = JSON.parse(this.text);
-                    root.localWallpapers = list || [];
-                } catch (e) {
-                    console.error("WallpaperSelector: Failed to parse local wallpapers", e);
-                    root.localWallpapers = [];
-                }
-            }
+    function handleRefresh() {
+        if (sourceMode === 0) {
+            ThemeManager.refreshLocalWallpapers();
+        } else if (sourceMode === 1) {
+            ThemeManager.refreshDownloadedWallpapers();
+        } else {
+            searchWallhaven(true);
         }
     }
 
-    Process {
-        id: downloadedWallpapersProcess
-        stdout: StdioCollector {
-            onStreamFinished: {
-                try {
-                    const list = JSON.parse(this.text);
-                    root.downloadedWallpapers = list || [];
-                } catch (e) {
-                    console.error("WallpaperSelector: Failed to parse downloaded wallpapers", e);
-                    root.downloadedWallpapers = [];
+    // Listen to ThemeManager signals
+    Connections {
+        target: ThemeManager
+
+        function onFetchingWallhavenWallpapersStarted() {
+            root.wallhavenLoading = true;
+        }
+
+        function onWallhavenWallpapersFetched(response) {
+            root.wallhavenLoading = false;
+            if (response.data && Array.isArray(response.data)) {
+                const newWallpapers = response.data.map(w => ({
+                    id: w.id,
+                    path: w.path,
+                    thumb: w.thumbs.large,
+                    resolution: w.resolution,
+                    file_type: w.file_type,
+                    views: w.views,
+                    favorites: w.favorites
+                }));
+                
+                if (root.wallhavenPage === 1) {
+                    root.wallhavenWallpapers = newWallpapers;
+                } else {
+                    root.wallhavenWallpapers = root.wallhavenWallpapers.concat(newWallpapers);
+                }
+
+                if (response.meta) {
+                    root.wallhavenHasMore = response.meta.current_page < response.meta.last_page;
                 }
             }
         }
-    }
 
-    Process {
-        id: wallhavenProcess
-        stdout: StdioCollector {
-            onStreamFinished: {
-                root.wallhavenLoading = false;
-                try {
-                    const response = JSON.parse(this.text);
-                    if (response.data && Array.isArray(response.data)) {
-                        const newWallpapers = response.data.map(w => ({
-                            id: w.id,
-                            path: w.path,
-                            thumb: w.thumbs.large,
-                            resolution: w.resolution,
-                            file_type: w.file_type,
-                            views: w.views,
-                            favorites: w.favorites
-                        }));
-                        
-                        if (root.wallhavenPage === 1) {
-                            root.wallhavenWallpapers = newWallpapers;
-                        } else {
-                            root.wallhavenWallpapers = root.wallhavenWallpapers.concat(newWallpapers);
-                        }
-
-                        // Check if there are more pages
-                        if (response.meta) {
-                            root.wallhavenHasMore = response.meta.current_page < response.meta.last_page;
-                        }
-                    }
-                } catch (e) {
-                    console.error("WallpaperSelector: Failed to parse Wallhaven response", e);
-                }
-            }
+        function onWallhavenWallpapersError(errorDetails) {
+            root.wallhavenLoading = false;
+            console.error("WallpaperSelector: Wallhaven error -", errorDetails);
         }
-    }
 
-    Process {
-        id: wallhavenDownloadProcess
-        property string wallpaperPath: ""
-        
-        onExited: (exitCode, exitStatus) => {
-            if (exitCode === 0 && wallpaperPath !== "") {
-                root.applyWallpaper(wallpaperPath);
-                // Refresh downloaded list after successful download
-                root.loadDownloadedWallpapers();
-            } else {
-                console.error("WallpaperSelector: Download failed with exit code", exitCode);
-            }
+        function onWallpaperDownloadFinished(filePath) {
+            root.applyWallpaper(filePath);
+        }
+
+        function onWallpaperDownloadError(errorDetails) {
+            console.error("WallpaperSelector: Download error -", errorDetails);
         }
     }
 
@@ -310,988 +182,75 @@ Item {
         anchors.fill: parent
         spacing: 10
 
-        // Header
-        RowLayout {
+        WallpaperHeader {
             Layout.fillWidth: true
-            spacing: 12
+            isLoading: root.wallhavenLoading
+            sourceMode: root.sourceMode
+            onRefreshClicked: root.handleRefresh()
+            onCloseClicked: root.closeRequested()
+        }
 
-            Text {
-                text: "󰸉"
-                font.pixelSize: 24
-                font.family: ThemeManager.selectedTheme?.typography?.iconFont || "Material Design Icons"
-                color: ThemeManager.selectedTheme?.colors?.primary || "#fff"
-            }
-
-            ColumnLayout {
-                Layout.fillWidth: true
-                spacing: 2
-
-                Text {
-                    text: qsTr("Wallpaper Selector")
-                    font.pixelSize: 16
-                    font.bold: true
-                    color: ThemeManager.selectedTheme?.colors?.leftMenuFgColorV1 || "#fff"
-                }
-
-                Text {
-                    text: sourceMode === 2 ? qsTr("Browse wallpapers from Wallhaven.cc") : qsTr("Select a wallpaper to apply")
-                    font.pixelSize: 11
-                    color: ThemeManager.selectedTheme?.colors?.subtleText || "#888"
-                }
-            }
-
-            // Refresh button
-            Rectangle {
-                width: 28
-                height: 28
-                radius: 6
-                color: refreshMouseArea.containsMouse 
-                    ? ThemeManager.selectedTheme?.colors?.primary.alpha(0.2) || "#333"
-                    : "transparent"
-
-                Text {
-                    anchors.centerIn: parent
-                    text: root.wallhavenLoading ? "󰦖" : "󰑐"
-                    font.pixelSize: 16
-                    font.family: ThemeManager.selectedTheme?.typography?.iconFont || "Material Design Icons"
-                    color: ThemeManager.selectedTheme?.colors?.subtleText || "#888"
-
-                    RotationAnimation on rotation {
-                        running: root.wallhavenLoading
-                        from: 0
-                        to: 360
-                        duration: 1000
-                        loops: Animation.Infinite
-                    }
-                }
-
-                MouseArea {
-                    id: refreshMouseArea
-                    anchors.fill: parent
-                    hoverEnabled: true
-                    cursorShape: Qt.PointingHandCursor
-                    onClicked: {
-                        if (root.sourceMode === 0) {
-                            root.loadLocalWallpapers();
-                        } else if (root.sourceMode === 1) {
-                            root.loadCustomWallpapers();
-                        } else {
-                            root.searchWallhaven(true);
-                        }
-                    }
-                }
-            }
-
-            // Close button
-            Rectangle {
-                width: 28
-                height: 28
-                radius: 6
-                color: closeMouseArea.containsMouse 
-                    ? ThemeManager.selectedTheme?.colors?.primary.alpha(0.2) || "#333"
-                    : "transparent"
-
-                Text {
-                    anchors.centerIn: parent
-                    text: "󰅖"
-                    font.pixelSize: 16
-                    font.family: ThemeManager.selectedTheme?.typography?.iconFont || "Material Design Icons"
-                    color: ThemeManager.selectedTheme?.colors?.subtleText || "#888"
-                }
-
-                MouseArea {
-                    id: closeMouseArea
-                    anchors.fill: parent
-                    hoverEnabled: true
-                    cursorShape: Qt.PointingHandCursor
-                    onClicked: root.closeRequested()
+        SourceTabs {
+            Layout.fillWidth: true
+            currentSource: root.sourceMode
+            onSourceSelected: index => {
+                root.sourceMode = index;
+                if (index === 2 && root.wallhavenWallpapers.length === 0) {
+                    root.searchWallhaven(true);
                 }
             }
         }
 
-        // Source tabs
-        RowLayout {
+        SearchBar {
             Layout.fillWidth: true
-            spacing: 4
-
-            Repeater {
-                model: root.sourceNames
-
-                Rectangle {
-                    id: tabRect
-                    required property int index
-                    required property string modelData
-                    
-                    Layout.fillWidth: true
-                    height: 32
-                    radius: ThemeManager.selectedTheme?.dimensions?.elementRadius || 8
-                    color: root.sourceMode === tabRect.index
-                        ? ThemeManager.selectedTheme?.colors?.primary.alpha(0.2) || "#333"
-                        : tabMouseArea.containsMouse
-                            ? ThemeManager.selectedTheme?.colors?.primary.alpha(0.1) || "#222"
-                            : "transparent"
-                    border.color: root.sourceMode === tabRect.index
-                        ? ThemeManager.selectedTheme?.colors?.primary || "#6366f1"
-                        : "transparent"
-                    border.width: 1
-
-                    Text {
-                        anchors.centerIn: parent
-                        text: tabRect.modelData
-                        font.pixelSize: 12
-                        font.weight: root.sourceMode === tabRect.index ? Font.Bold : Font.Normal
-                        color: root.sourceMode === tabRect.index
-                            ? ThemeManager.selectedTheme?.colors?.primary || "#6366f1"
-                            : ThemeManager.selectedTheme?.colors?.leftMenuFgColorV1 || "#fff"
-                    }
-
-                    MouseArea {
-                        id: tabMouseArea
-                        anchors.fill: parent
-                        hoverEnabled: true
-                        cursorShape: Qt.PointingHandCursor
-                        onClicked: {
-                            root.sourceMode = tabRect.index;
-                            if (tabRect.index === 2 && root.wallhavenWallpapers.length === 0) {
-                                root.searchWallhaven(true);
-                            }
-                        }
-                    }
+            sourceMode: root.sourceMode
+            onFilterTextChanged: text => {
+                if (root.sourceMode === 2) {
+                    root.wallhavenQuery = text;
+                } else {
+                    root.filterText = text;
                 }
             }
+            onSearchRequested: root.searchWallhaven(true)
         }
 
-        // Search bar
-        RowLayout {
+        WallhavenFilters {
             Layout.fillWidth: true
-            spacing: 8
-
-            EditableField {
-                id: searchField
-                Layout.fillWidth: true
-                Layout.preferredHeight: 36
-
-                placeholderText: root.sourceMode === 2 
-                    ? qsTr("Search Wallhaven (e.g. nature, anime, abstract)...")
-                    : qsTr("Filter wallpapers...")
-                font.pixelSize: 13
-                horizontalAlignment: Text.AlignLeft
-
-                normalBackground: ThemeManager.selectedTheme?.colors?.leftMenuBgColorV2 || "#222"
-                normalForeground: ThemeManager.selectedTheme?.colors?.leftMenuFgColorV1 || "#fff"
-                focusedBorderColor: ThemeManager.selectedTheme?.colors?.primary || "#6366f1"
-                borderColor: ThemeManager.selectedTheme?.colors?.primary.alpha(0.3) || "#444"
-                borderSize: 1
-
-                topLeftRadius: ThemeManager.selectedTheme?.dimensions?.elementRadius || 8
-                topRightRadius: ThemeManager.selectedTheme?.dimensions?.elementRadius || 8
-                bottomLeftRadius: ThemeManager.selectedTheme?.dimensions?.elementRadius || 8
-                bottomRightRadius: ThemeManager.selectedTheme?.dimensions?.elementRadius || 8
-
-                onTextChanged: {
-                    if (root.sourceMode === 2) {
-                        root.wallhavenQuery = text;
-                    } else {
-                        root.filterText = text;
-                    }
-                }
-
-                onAccepted: {
-                    if (root.sourceMode === 2) {
-                        root.searchWallhaven(true);
-                    }
-                }
-            }
-
-            // Search button for Wallhaven
-            Rectangle {
-                Layout.preferredWidth: 36
-                Layout.preferredHeight: 36
-                radius: ThemeManager.selectedTheme?.dimensions?.elementRadius || 8
-                visible: root.sourceMode === 2
-                color: searchBtnMouse.containsMouse
-                    ? ThemeManager.selectedTheme?.colors?.primary || "#6366f1"
-                    : ThemeManager.selectedTheme?.colors?.primary.alpha(0.8) || "#5558e8"
-
-                Text {
-                    anchors.centerIn: parent
-                    text: "󰍉"
-                    font.pixelSize: 16
-                    font.family: ThemeManager.selectedTheme?.typography?.iconFont || "Material Design Icons"
-                    color: "#fff"
-                }
-
-                MouseArea {
-                    id: searchBtnMouse
-                    anchors.fill: parent
-                    hoverEnabled: true
-                    cursorShape: Qt.PointingHandCursor
-                    onClicked: root.searchWallhaven(true)
-                }
-            }
-        }
-
-        // Wallhaven filters (only when Wallhaven is selected)
-        Flow {
-            Layout.fillWidth: true
-            spacing: 6
             visible: root.sourceMode === 2
 
-            // Sorting dropdown with order and topRange
-            Rectangle {
-                id: sortingBtn
-                width: sortingText.width + 16
-                height: 28
-                radius: 6
-                color: ThemeManager.selectedTheme?.colors?.leftMenuBgColorV2 || "#222"
+            sorting: root.wallhavenSorting
+            order: root.wallhavenOrder
+            topRange: root.wallhavenTopRange
+            category: root.wallhavenCategory
+            color: root.wallhavenColor
+            resolution: root.wallhavenResolution
 
-                Text {
-                    id: sortingText
-                    anchors.centerIn: parent
-                    text: {
-                        const sorts = { "toplist": "Top", "date_added": "New", "random": "Random", "views": "Views", "relevance": "Relevant", "favorites": "Fav" };
-                        let label = sorts[root.wallhavenSorting] || "Top";
-                        if (root.wallhavenSorting === "toplist") {
-                            const range = root.topRangePresets.find(r => r.value === root.wallhavenTopRange);
-                            label += " (" + (range ? range.name : root.wallhavenTopRange) + ")";
-                        }
-                        label += root.wallhavenOrder === "asc" ? " ↑" : " ↓";
-                        return label;
-                    }
-                    font.pixelSize: 11
-                    color: ThemeManager.selectedTheme?.colors?.leftMenuFgColorV1 || "#fff"
-                }
-
-                MouseArea {
-                    anchors.fill: parent
-                    cursorShape: Qt.PointingHandCursor
-                    onClicked: sortingPopup.visible ? sortingPopup.close() : sortingPopup.open()
-                }
-
-                Popup {
-                    id: sortingPopup
-                    x: 0
-                    y: -height - 4
-                    width: 180
-                    padding: 8
-                    closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
-
-                    background: Rectangle {
-                        color: ThemeManager.selectedTheme?.colors?.leftMenuBgColorV1 || "#1a1a2e"
-                        radius: 8
-                        border.color: ThemeManager.selectedTheme?.colors?.primary.alpha(0.3) || "#444"
-                        border.width: 1
-                    }
-
-                    contentItem: Column {
-                        spacing: 6
-
-                        // Sort + Order in one row each
-                        Grid {
-                            columns: 3
-                            spacing: 4
-
-                            Repeater {
-                                model: [
-                                    { name: "Top", value: "toplist" },
-                                    { name: "New", value: "date_added" },
-                                    { name: "Random", value: "random" },
-                                    { name: "Views", value: "views" },
-                                    { name: "Fav", value: "favorites" },
-                                    { name: "Relevant", value: "relevance" }
-                                ]
-
-                                Rectangle {
-                                    id: sortOptionRect
-                                    required property var modelData
-                                    width: 52
-                                    height: 26
-                                    radius: 4
-                                    color: root.wallhavenSorting === sortOptionRect.modelData.value
-                                        ? ThemeManager.selectedTheme?.colors?.primary.alpha(0.3) || "#333"
-                                        : ThemeManager.selectedTheme?.colors?.leftMenuBgColorV2 || "#222"
-                                    border.color: root.wallhavenSorting === sortOptionRect.modelData.value
-                                        ? ThemeManager.selectedTheme?.colors?.primary || "#6366f1"
-                                        : "transparent"
-                                    border.width: 1
-
-                                    Text {
-                                        anchors.centerIn: parent
-                                        text: sortOptionRect.modelData.name
-                                        font.pixelSize: 10
-                                        color: root.wallhavenSorting === sortOptionRect.modelData.value
-                                            ? ThemeManager.selectedTheme?.colors?.primary || "#6366f1"
-                                            : ThemeManager.selectedTheme?.colors?.leftMenuFgColorV1 || "#fff"
-                                    }
-
-                                    MouseArea {
-                                        anchors.fill: parent
-                                        cursorShape: Qt.PointingHandCursor
-                                        onClicked: {
-                                            root.wallhavenSorting = sortOptionRect.modelData.value;
-                                            root.searchWallhaven(true);
-                                        }
-                                    }
-                                }
-                            }
-                        }
-
-                        // Order row
-                        Row {
-                            spacing: 4
-
-                            Repeater {
-                                model: [
-                                    { name: "Desc ↓", value: "desc" },
-                                    { name: "Asc ↑", value: "asc" }
-                                ]
-
-                                Rectangle {
-                                    id: orderRect
-                                    required property var modelData
-                                    width: 80
-                                    height: 26
-                                    radius: 4
-                                    color: root.wallhavenOrder === orderRect.modelData.value
-                                        ? ThemeManager.selectedTheme?.colors?.primary.alpha(0.3) || "#333"
-                                        : ThemeManager.selectedTheme?.colors?.leftMenuBgColorV2 || "#222"
-                                    border.color: root.wallhavenOrder === orderRect.modelData.value
-                                        ? ThemeManager.selectedTheme?.colors?.primary || "#6366f1"
-                                        : "transparent"
-                                    border.width: 1
-
-                                    Text {
-                                        anchors.centerIn: parent
-                                        text: orderRect.modelData.name
-                                        font.pixelSize: 10
-                                        color: root.wallhavenOrder === orderRect.modelData.value
-                                            ? ThemeManager.selectedTheme?.colors?.primary || "#6366f1"
-                                            : ThemeManager.selectedTheme?.colors?.leftMenuFgColorV1 || "#fff"
-                                    }
-
-                                    MouseArea {
-                                        anchors.fill: parent
-                                        cursorShape: Qt.PointingHandCursor
-                                        onClicked: {
-                                            root.wallhavenOrder = orderRect.modelData.value;
-                                            root.searchWallhaven(true);
-                                        }
-                                    }
-                                }
-                            }
-                        }
-
-                        // Time Range (only for toplist)
-                        Column {
-                            spacing: 4
-                            visible: root.wallhavenSorting === "toplist"
-
-                            Rectangle {
-                                width: 164
-                                height: 1
-                                color: ThemeManager.selectedTheme?.colors?.primary.alpha(0.2) || "#333"
-                            }
-
-                            Text {
-                                text: "Time Range"
-                                font.pixelSize: 9
-                                color: ThemeManager.selectedTheme?.colors?.subtleText || "#888"
-                            }
-
-                            Grid {
-                                columns: 2
-                                spacing: 4
-
-                                Repeater {
-                                    model: root.topRangePresets
-
-                                    Rectangle {
-                                        id: rangeRect
-                                        required property var modelData
-                                        width: 78
-                                        height: 24
-                                        radius: 4
-                                        color: root.wallhavenTopRange === rangeRect.modelData.value
-                                            ? ThemeManager.selectedTheme?.colors?.primary.alpha(0.3) || "#333"
-                                            : ThemeManager.selectedTheme?.colors?.leftMenuBgColorV2 || "#222"
-                                        border.color: root.wallhavenTopRange === rangeRect.modelData.value
-                                            ? ThemeManager.selectedTheme?.colors?.primary || "#6366f1"
-                                            : "transparent"
-                                        border.width: 1
-
-                                        Text {
-                                            anchors.centerIn: parent
-                                            text: rangeRect.modelData.name
-                                            font.pixelSize: 10
-                                            color: root.wallhavenTopRange === rangeRect.modelData.value
-                                                ? ThemeManager.selectedTheme?.colors?.primary || "#6366f1"
-                                                : ThemeManager.selectedTheme?.colors?.leftMenuFgColorV1 || "#fff"
-                                        }
-
-                                        MouseArea {
-                                            anchors.fill: parent
-                                            cursorShape: Qt.PointingHandCursor
-                                            onClicked: {
-                                                root.wallhavenTopRange = rangeRect.modelData.value;
-                                                root.searchWallhaven(true);
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-
-            // Categories dropdown
-            Rectangle {
-                id: categoriesBtn
-                width: catBtnText.width + 16
-                height: 28
-                radius: 6
-                color: ThemeManager.selectedTheme?.colors?.leftMenuBgColorV2 || "#222"
-
-                Text {
-                    id: catBtnText
-                    anchors.centerIn: parent
-                    text: "Categories"
-                    font.pixelSize: 11
-                    color: ThemeManager.selectedTheme?.colors?.leftMenuFgColorV1 || "#fff"
-                }
-
-                MouseArea {
-                    anchors.fill: parent
-                    cursorShape: Qt.PointingHandCursor
-                    onClicked: categoriesPopup.visible ? categoriesPopup.close() : categoriesPopup.open()
-                }
-
-                Popup {
-                    id: categoriesPopup
-                    x: 0
-                    y: -height - 4
-                    padding: 8
-                    closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
-
-                    background: Rectangle {
-                        color: ThemeManager.selectedTheme?.colors?.leftMenuBgColorV1 || "#1a1a2e"
-                        radius: 8
-                        border.color: ThemeManager.selectedTheme?.colors?.primary.alpha(0.3) || "#444"
-                        border.width: 1
-                    }
-
-                    contentItem: Column {
-                        spacing: 4
-
-                        Repeater {
-                            model: [
-                                { label: "General", mask: 0 },
-                                { label: "Anime", mask: 1 },
-                                { label: "People", mask: 2 }
-                            ]
-
-                            Rectangle {
-                                id: catPopupRect
-                                required property var modelData
-                                property bool isOn: root.wallhavenCategory.charAt(catPopupRect.modelData.mask) === "1"
-                                
-                                width: 100
-                                height: 28
-                                radius: 4
-                                color: catPopupRect.isOn
-                                    ? ThemeManager.selectedTheme?.colors?.primary.alpha(0.3) || "#333"
-                                    : ThemeManager.selectedTheme?.colors?.leftMenuBgColorV2 || "#222"
-                                border.color: catPopupRect.isOn
-                                    ? ThemeManager.selectedTheme?.colors?.primary || "#6366f1"
-                                    : "transparent"
-                                border.width: 1
-
-                                Row {
-                                    anchors.centerIn: parent
-                                    spacing: 6
-
-                                    Rectangle {
-                                        width: 14
-                                        height: 14
-                                        radius: 3
-                                        anchors.verticalCenter: parent.verticalCenter
-                                        color: catPopupRect.isOn 
-                                            ? ThemeManager.selectedTheme?.colors?.primary || "#6366f1"
-                                            : "transparent"
-                                        border.color: ThemeManager.selectedTheme?.colors?.primary || "#6366f1"
-                                        border.width: 1
-
-                                        Text {
-                                            anchors.centerIn: parent
-                                            text: catPopupRect.isOn ? "✓" : ""
-                                            font.pixelSize: 10
-                                            color: "#fff"
-                                        }
-                                    }
-
-                                    Text {
-                                        text: catPopupRect.modelData.label
-                                        font.pixelSize: 11
-                                        anchors.verticalCenter: parent.verticalCenter
-                                        color: catPopupRect.isOn
-                                            ? ThemeManager.selectedTheme?.colors?.primary || "#6366f1"
-                                            : ThemeManager.selectedTheme?.colors?.leftMenuFgColorV1 || "#fff"
-                                    }
-                                }
-
-                                MouseArea {
-                                    anchors.fill: parent
-                                    cursorShape: Qt.PointingHandCursor
-                                    onClicked: {
-                                        let cats = root.wallhavenCategory.split("");
-                                        cats[catPopupRect.modelData.mask] = cats[catPopupRect.modelData.mask] === "1" ? "0" : "1";
-                                        if (cats.join("") !== "000") {
-                                            root.wallhavenCategory = cats.join("");
-                                            root.searchWallhaven(true);
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-
-            // Color filter
-            Rectangle {
-                id: colorFilterBtn
-                height: 28
-                width: colorFilterRow.width + 12
-                radius: 6
-                color: ThemeManager.selectedTheme?.colors?.leftMenuBgColorV2 || "#222"
-                border.color: root.wallhavenColor !== "" ? ThemeManager.selectedTheme?.colors?.primary || "#6366f1" : "transparent"
-                border.width: 1
-
-                Row {
-                    id: colorFilterRow
-                    anchors.centerIn: parent
-                    spacing: 4
-
-                    Rectangle {
-                        width: 14
-                        height: 14
-                        radius: 7
-                        anchors.verticalCenter: parent.verticalCenter
-                        color: root.wallhavenColor !== "" ? ("#" + root.wallhavenColor) : "transparent"
-                        border.color: root.wallhavenColor === "" 
-                            ? ThemeManager.selectedTheme?.colors?.subtleText || "#666" 
-                            : "transparent"
-                        border.width: 1
-
-                        Text {
-                            anchors.centerIn: parent
-                            text: root.wallhavenColor === "" ? "?" : ""
-                            font.pixelSize: 9
-                            color: ThemeManager.selectedTheme?.colors?.subtleText || "#888"
-                        }
-                    }
-
-                    Text {
-                        text: root.wallhavenColor === "" ? "Color" : root.colorPresets.find(c => c.hex === root.wallhavenColor)?.name || "Custom"
-                        font.pixelSize: 11
-                        anchors.verticalCenter: parent.verticalCenter
-                        color: root.wallhavenColor !== ""
-                            ? ThemeManager.selectedTheme?.colors?.primary || "#6366f1"
-                            : ThemeManager.selectedTheme?.colors?.subtleText || "#888"
-                    }
-                }
-
-                MouseArea {
-                    anchors.fill: parent
-                    cursorShape: Qt.PointingHandCursor
-                    onClicked: colorPopup.open()
-                }
-
-                Popup {
-                    id: colorPopup
-                    x: 0
-                    y: parent.height + 4
-                    width: 220
-                    padding: 8
-
-                    background: Rectangle {
-                        color: ThemeManager.selectedTheme?.colors?.leftMenuBgColorV1 || "#1a1a2e"
-                        radius: 8
-                        border.color: ThemeManager.selectedTheme?.colors?.primary.alpha(0.3) || "#444"
-                        border.width: 1
-                    }
-
-                    contentItem: Grid {
-                        columns: 6
-                        spacing: 4
-
-                        Repeater {
-                            model: root.colorPresets
-
-                            Rectangle {
-                                id: colorPresetRect
-                                required property var modelData
-                                required property int index
-
-                                width: 32
-                                height: 24
-                                radius: 4
-                                color: colorPresetRect.modelData.hex === "" 
-                                    ? ThemeManager.selectedTheme?.colors?.leftMenuBgColorV2 || "#333"
-                                    : ("#" + colorPresetRect.modelData.hex)
-                                border.color: root.wallhavenColor === colorPresetRect.modelData.hex
-                                    ? ThemeManager.selectedTheme?.colors?.primary || "#6366f1"
-                                    : (colorPresetRect.modelData.hex === "ffffff" || colorPresetRect.modelData.hex === "cccccc" ? "#999" : "transparent")
-                                border.width: root.wallhavenColor === colorPresetRect.modelData.hex ? 2 : 1
-
-                                Text {
-                                    anchors.centerIn: parent
-                                    text: colorPresetRect.modelData.hex === "" ? "✕" : ""
-                                    font.pixelSize: 12
-                                    color: ThemeManager.selectedTheme?.colors?.subtleText || "#888"
-                                }
-
-                                MouseArea {
-                                    anchors.fill: parent
-                                    cursorShape: Qt.PointingHandCursor
-                                    hoverEnabled: true
-                                    onClicked: {
-                                        root.wallhavenColor = colorPresetRect.modelData.hex;
-                                        colorPopup.close();
-                                        root.searchWallhaven(true);
-                                    }
-                                }
-
-                                ToolTip.visible: colorPresetMouse.containsMouse
-                                ToolTip.text: colorPresetRect.modelData.name
-                                ToolTip.delay: 500
-
-                                MouseArea {
-                                    id: colorPresetMouse
-                                    anchors.fill: parent
-                                    hoverEnabled: true
-                                    cursorShape: Qt.PointingHandCursor
-                                    onClicked: {
-                                        root.wallhavenColor = colorPresetRect.modelData.hex;
-                                        colorPopup.close();
-                                        root.searchWallhaven(true);
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-
-            // Resolution filter
-            Rectangle {
-                id: resFilterBtn
-                height: 28
-                width: resFilterText.width + 12
-                radius: 6
-                color: ThemeManager.selectedTheme?.colors?.leftMenuBgColorV2 || "#222"
-                border.color: root.wallhavenResolution !== "" ? ThemeManager.selectedTheme?.colors?.primary || "#6366f1" : "transparent"
-                border.width: 1
-
-                Text {
-                    id: resFilterText
-                    anchors.centerIn: parent
-                    text: root.wallhavenResolution === "" ? "Resolution" : root.resolutionPresets.find(r => r.value === root.wallhavenResolution)?.name || root.wallhavenResolution
-                    font.pixelSize: 11
-                    color: root.wallhavenResolution !== ""
-                        ? ThemeManager.selectedTheme?.colors?.primary || "#6366f1"
-                        : ThemeManager.selectedTheme?.colors?.subtleText || "#888"
-                }
-
-                MouseArea {
-                    anchors.fill: parent
-                    cursorShape: Qt.PointingHandCursor
-                    onClicked: resPopup.open()
-                }
-
-                Popup {
-                    id: resPopup
-                    x: 0
-                    y: parent.height + 4
-                    width: 120
-                    padding: 8
-
-                    background: Rectangle {
-                        color: ThemeManager.selectedTheme?.colors?.leftMenuBgColorV1 || "#1a1a2e"
-                        radius: 8
-                        border.color: ThemeManager.selectedTheme?.colors?.primary.alpha(0.3) || "#444"
-                        border.width: 1
-                    }
-
-                    contentItem: Column {
-                        spacing: 4
-
-                        Repeater {
-                            model: root.resolutionPresets
-
-                            Rectangle {
-                                id: resPresetRect
-                                required property var modelData
-                                required property int index
-
-                                width: 104
-                                height: 28
-                                radius: 6
-                                color: root.wallhavenResolution === resPresetRect.modelData.value
-                                    ? ThemeManager.selectedTheme?.colors?.primary.alpha(0.2) || "#333"
-                                    : resPresetMouse.containsMouse
-                                        ? ThemeManager.selectedTheme?.colors?.primary.alpha(0.1) || "#222"
-                                        : "transparent"
-                                border.color: root.wallhavenResolution === resPresetRect.modelData.value
-                                    ? ThemeManager.selectedTheme?.colors?.primary || "#6366f1"
-                                    : "transparent"
-                                border.width: 1
-
-                                Text {
-                                    anchors.centerIn: parent
-                                    text: resPresetRect.modelData.name + (resPresetRect.modelData.value !== "" ? "+" : "")
-                                    font.pixelSize: 11
-                                    color: root.wallhavenResolution === resPresetRect.modelData.value
-                                        ? ThemeManager.selectedTheme?.colors?.primary || "#6366f1"
-                                        : ThemeManager.selectedTheme?.colors?.leftMenuFgColorV1 || "#fff"
-                                }
-
-                                MouseArea {
-                                    id: resPresetMouse
-                                    anchors.fill: parent
-                                    hoverEnabled: true
-                                    cursorShape: Qt.PointingHandCursor
-                                    onClicked: {
-                                        root.wallhavenResolution = resPresetRect.modelData.value;
-                                        resPopup.close();
-                                        root.searchWallhaven(true);
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
+            onSortingSelected: value => { root.wallhavenSorting = value; root.searchWallhaven(true); }
+            onOrderSelected: value => { root.wallhavenOrder = value; root.searchWallhaven(true); }
+            onTopRangeSelected: value => { root.wallhavenTopRange = value; root.searchWallhaven(true); }
+            onCategorySelected: value => { root.wallhavenCategory = value; root.searchWallhaven(true); }
+            onColorSelected: value => { root.wallhavenColor = value; root.searchWallhaven(true); }
+            onResolutionSelected: value => { root.wallhavenResolution = value; root.searchWallhaven(true); }
         }
 
-        // Wallpaper Grid
-        Rectangle {
+        WallpaperGrid {
             Layout.fillWidth: true
             Layout.fillHeight: true
-            radius: ThemeManager.selectedTheme?.dimensions?.elementRadius || 8
-            color: ThemeManager.selectedTheme?.colors?.leftMenuBgColorV2 || "#1a1a2e"
-            clip: true
 
-            GridView {
-                id: wallpaperGrid
-                anchors.fill: parent
-                anchors.margins: 8
-
-                property int columns: root.compact ? 1 : 4
-                cellWidth: (width - 16) / columns
-                cellHeight: root.compact ? cellWidth * 0.5 + 24 : cellWidth * 0.6 + 28
-
-                model: root.filteredWallpapers
-                clip: true
-                boundsBehavior: Flickable.StopAtBounds
-
-                ScrollBar.vertical: ScrollBar {
-                    active: true
-                    policy: ScrollBar.AsNeeded
+            wallpapers: root.filteredWallpapers
+            isWallhaven: root.sourceMode === 2
+            loading: root.wallhavenLoading
+            compact: root.compact
+            currentWallpaper: ThemeManager.currentWallpaper
+            emptyText: {
+                if (root.sourceMode === 2) {
+                    return qsTr("Search for wallpapers or click refresh to load top wallpapers");
                 }
-
-                onAtYEndChanged: {
-                    if (atYEnd && root.sourceMode === 2 && !root.wallhavenLoading && root.wallhavenHasMore) {
-                        root.loadMoreWallhaven();
-                    }
-                }
-
-                delegate: Item {
-                    id: wallpaperDelegate
-                    required property int index
-                    required property var modelData
-
-                    width: wallpaperGrid.cellWidth
-                    height: wallpaperGrid.cellHeight
-
-                    property bool isWallhaven: root.sourceMode === 2
-                    property string thumbUrl: isWallhaven ? modelData.thumb : ("file://" + modelData)
-                    property string wallpaperPath: isWallhaven ? modelData.path : modelData
-                    property string displayName: isWallhaven 
-                        ? (modelData.resolution || modelData.id)
-                        : modelData.split('/').pop()
-
-                    Rectangle {
-                        id: cardBg
-                        anchors.fill: parent
-                        anchors.margins: 4
-                        radius: ThemeManager.selectedTheme?.dimensions?.elementRadius || 8
-                        color: itemMouseArea.containsMouse 
-                            ? ThemeManager.selectedTheme?.colors?.primary.alpha(0.15) || "#333"
-                            : "transparent"
-                        border.color: ThemeManager.currentWallpaper === wallpaperDelegate.wallpaperPath
-                            ? ThemeManager.selectedTheme?.colors?.primary || "#6366f1"
-                            : itemMouseArea.containsMouse 
-                                ? ThemeManager.selectedTheme?.colors?.primary.alpha(0.5) || "#555"
-                                : "transparent"
-                        border.width: ThemeManager.currentWallpaper === wallpaperDelegate.wallpaperPath ? 2 : 1
-
-                        Behavior on color {
-                            ColorAnimation { duration: 150 }
-                        }
-
-                        ColumnLayout {
-                            anchors.fill: parent
-                            anchors.margins: 4
-                            spacing: 4
-
-                            Rectangle {
-                                Layout.fillWidth: true
-                                Layout.fillHeight: true
-                                radius: (ThemeManager.selectedTheme?.dimensions?.elementRadius || 8) - 2
-                                color: ThemeManager.selectedTheme?.colors?.leftMenuBgColorV1 || "#111"
-                                clip: true
-
-                                Image {
-                                    id: thumbImage
-                                    anchors.fill: parent
-                                    source: wallpaperDelegate.thumbUrl
-                                    fillMode: Image.PreserveAspectCrop
-                                    asynchronous: true
-                                    sourceSize: Qt.size(300, 200)
-                                }
-
-                                // Loading indicator
-                                Rectangle {
-                                    anchors.centerIn: parent
-                                    width: 24
-                                    height: 24
-                                    radius: 12
-                                    color: ThemeManager.selectedTheme?.colors?.primary.alpha(0.3) || "#333"
-                                    visible: thumbImage.status === Image.Loading
-
-                                    Text {
-                                        anchors.centerIn: parent
-                                        text: "󰑐"
-                                        font.pixelSize: 14
-                                        font.family: ThemeManager.selectedTheme?.typography?.iconFont || "Material Design Icons"
-                                        color: ThemeManager.selectedTheme?.colors?.primary || "#6366f1"
-
-                                        RotationAnimation on rotation {
-                                            running: thumbImage.status === Image.Loading
-                                            from: 0
-                                            to: 360
-                                            duration: 1000
-                                            loops: Animation.Infinite
-                                        }
-                                    }
-                                }
-
-                                // Wallhaven badge
-                                Rectangle {
-                                    anchors.top: parent.top
-                                    anchors.left: parent.left
-                                    anchors.margins: 4
-                                    height: 16
-                                    width: favText.width + 8
-                                    radius: 4
-                                    color: "#000000aa"
-                                    visible: wallpaperDelegate.isWallhaven && modelData.favorites > 0
-
-                                    Text {
-                                        id: favText
-                                        anchors.centerIn: parent
-                                        text: "♥ " + modelData.favorites
-                                        font.pixelSize: 9
-                                        color: "#ff6b6b"
-                                    }
-                                }
-                            }
-
-                            Text {
-                                Layout.fillWidth: true
-                                text: wallpaperDelegate.displayName
-                                font.pixelSize: 10
-                                color: ThemeManager.selectedTheme?.colors?.subtleText || "#888"
-                                elide: Text.ElideMiddle
-                                horizontalAlignment: Text.AlignHCenter
-                            }
-                        }
-
-                        MouseArea {
-                            id: itemMouseArea
-                            anchors.fill: parent
-                            hoverEnabled: true
-                            cursorShape: Qt.PointingHandCursor
-                            onClicked: root.selectWallpaper(wallpaperDelegate.modelData)
-                        }
-                    }
-                }
-
-                // Empty state
-                Text {
-                    anchors.centerIn: parent
-                    visible: root.filteredWallpapers.length === 0 && !root.wallhavenLoading
-                    text: {
-                        if (root.sourceMode === 2) {
-                            return qsTr("Search for wallpapers or click refresh to load top wallpapers");
-                        }
-                        if (root.sourceMode === 1 && root.customFolderPath === "") {
-                            return qsTr("No custom folder selected.\nClick the folder icon to choose a folder.");
-                        }
-                        return qsTr("No wallpapers found");
-                    }
-                    font.pixelSize: 14
-                    color: ThemeManager.selectedTheme?.colors?.subtleText || "#888"
-                    horizontalAlignment: Text.AlignHCenter
-                }
-
-                // Loading state for Wallhaven
-                Rectangle {
-                    anchors.centerIn: parent
-                    width: 48
-                    height: 48
-                    radius: 24
-                    color: ThemeManager.selectedTheme?.colors?.primary.alpha(0.2) || "#333"
-                    visible: root.wallhavenLoading && root.wallhavenWallpapers.length === 0
-
-                    Text {
-                        anchors.centerIn: parent
-                        text: "󰑐"
-                        font.pixelSize: 24
-                        font.family: ThemeManager.selectedTheme?.typography?.iconFont || "Material Design Icons"
-                        color: ThemeManager.selectedTheme?.colors?.primary || "#6366f1"
-
-                        RotationAnimation on rotation {
-                            running: root.wallhavenLoading
-                            from: 0
-                            to: 360
-                            duration: 1000
-                            loops: Animation.Infinite
-                        }
-                    }
-                }
+                return qsTr("No wallpapers found");
             }
 
-            // Load more indicator
-            Rectangle {
-                anchors.bottom: parent.bottom
-                anchors.horizontalCenter: parent.horizontalCenter
-                anchors.bottomMargin: 8
-                width: loadMoreText.width + 24
-                height: 28
-                radius: 14
-                color: ThemeManager.selectedTheme?.colors?.primary.alpha(0.9) || "#6366f1"
-                visible: root.sourceMode === 2 && root.wallhavenLoading && root.wallhavenWallpapers.length > 0
-
-                Text {
-                    id: loadMoreText
-                    anchors.centerIn: parent
-                    text: "Loading more..."
-                    font.pixelSize: 11
-                    color: "#fff"
-                }
-            }
+            onWallpaperClicked: wallpaperData => root.selectWallpaper(wallpaperData)
+            onLoadMore: root.loadMoreWallhaven()
         }
     }
 }

--- a/config/quickshell/components/wallpaper_selector/SearchBar.qml
+++ b/config/quickshell/components/wallpaper_selector/SearchBar.qml
@@ -1,0 +1,76 @@
+// components/wallpaper_selector/SearchBar.qml
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Layouts
+import "root:/themes"
+import "root:/components"
+
+RowLayout {
+    id: root
+
+    property int sourceMode: 0
+    property alias text: searchField.text
+
+    signal searchRequested
+    signal filterTextChanged(string text)
+
+    spacing: 8
+
+    EditableField {
+        id: searchField
+        Layout.fillWidth: true
+        Layout.preferredHeight: 36
+
+        placeholderText: root.sourceMode === 2 
+            ? qsTr("Search Wallhaven (e.g. nature, anime, abstract)...")
+            : qsTr("Filter wallpapers...")
+        font.pixelSize: 13
+        horizontalAlignment: Text.AlignLeft
+
+        normalBackground: ThemeManager.selectedTheme?.colors?.leftMenuBgColorV2 || "#222"
+        normalForeground: ThemeManager.selectedTheme?.colors?.leftMenuFgColorV1 || "#fff"
+        focusedBorderColor: ThemeManager.selectedTheme?.colors?.primary || "#6366f1"
+        borderColor: ThemeManager.selectedTheme?.colors?.primary.alpha(0.3) || "#444"
+        borderSize: 1
+
+        topLeftRadius: ThemeManager.selectedTheme?.dimensions?.elementRadius || 8
+        topRightRadius: ThemeManager.selectedTheme?.dimensions?.elementRadius || 8
+        bottomLeftRadius: ThemeManager.selectedTheme?.dimensions?.elementRadius || 8
+        bottomRightRadius: ThemeManager.selectedTheme?.dimensions?.elementRadius || 8
+
+        onTextChanged: root.filterTextChanged(text)
+        onAccepted: {
+            if (root.sourceMode === 2) {
+                root.searchRequested();
+            }
+        }
+    }
+
+    // Search button for Wallhaven
+    Rectangle {
+        Layout.preferredWidth: 36
+        Layout.preferredHeight: 36
+        radius: ThemeManager.selectedTheme?.dimensions?.elementRadius || 8
+        visible: root.sourceMode === 2
+        color: searchBtnMouse.containsMouse
+            ? ThemeManager.selectedTheme?.colors?.primary || "#6366f1"
+            : ThemeManager.selectedTheme?.colors?.primary.alpha(0.8) || "#5558e8"
+
+        Text {
+            anchors.centerIn: parent
+            text: "󰍉"
+            font.pixelSize: 16
+            font.family: ThemeManager.selectedTheme?.typography?.iconFont || "Material Design Icons"
+            color: "#fff"
+        }
+
+        MouseArea {
+            id: searchBtnMouse
+            anchors.fill: parent
+            hoverEnabled: true
+            cursorShape: Qt.PointingHandCursor
+            onClicked: root.searchRequested()
+        }
+    }
+}

--- a/config/quickshell/components/wallpaper_selector/SourceTabs.qml
+++ b/config/quickshell/components/wallpaper_selector/SourceTabs.qml
@@ -1,0 +1,58 @@
+// components/wallpaper_selector/SourceTabs.qml
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Layouts
+import "root:/themes"
+
+RowLayout {
+    id: root
+
+    property int currentSource: 0
+    property var sourceNames: ["Local", "Downloaded", "Wallhaven"]
+
+    signal sourceSelected(int index)
+
+    spacing: 4
+
+    Repeater {
+        model: root.sourceNames
+
+        Rectangle {
+            id: tabRect
+            required property int index
+            required property string modelData
+            
+            Layout.fillWidth: true
+            height: 32
+            radius: ThemeManager.selectedTheme?.dimensions?.elementRadius || 8
+            color: root.currentSource === tabRect.index
+                ? ThemeManager.selectedTheme?.colors?.primary.alpha(0.2) || "#333"
+                : tabMouseArea.containsMouse
+                    ? ThemeManager.selectedTheme?.colors?.primary.alpha(0.1) || "#222"
+                    : "transparent"
+            border.color: root.currentSource === tabRect.index
+                ? ThemeManager.selectedTheme?.colors?.primary || "#6366f1"
+                : "transparent"
+            border.width: 1
+
+            Text {
+                anchors.centerIn: parent
+                text: tabRect.modelData
+                font.pixelSize: 12
+                font.weight: root.currentSource === tabRect.index ? Font.Bold : Font.Normal
+                color: root.currentSource === tabRect.index
+                    ? ThemeManager.selectedTheme?.colors?.primary || "#6366f1"
+                    : ThemeManager.selectedTheme?.colors?.leftMenuFgColorV1 || "#fff"
+            }
+
+            MouseArea {
+                id: tabMouseArea
+                anchors.fill: parent
+                hoverEnabled: true
+                cursorShape: Qt.PointingHandCursor
+                onClicked: root.sourceSelected(tabRect.index)
+            }
+        }
+    }
+}

--- a/config/quickshell/components/wallpaper_selector/WallhavenFilters.qml
+++ b/config/quickshell/components/wallpaper_selector/WallhavenFilters.qml
@@ -1,0 +1,594 @@
+// components/wallpaper_selector/WallhavenFilters.qml
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+import "root:/themes"
+
+Flow {
+    id: root
+
+    property string sorting: "toplist"
+    property string order: "desc"
+    property string topRange: "1M"
+    property string category: "110"
+    property string color: ""
+    property string resolution: ""
+
+    // Internal preset data
+    readonly property var topRangePresets: [
+        { name: "Day", value: "1d" },
+        { name: "3 Days", value: "3d" },
+        { name: "Week", value: "1w" },
+        { name: "Month", value: "1M" },
+        { name: "3 Months", value: "3M" },
+        { name: "6 Months", value: "6M" },
+        { name: "1 Year", value: "1y" }
+    ]
+
+    readonly property var colorPresets: [
+        { name: "Any", hex: "" },
+        { name: "Lonestar", hex: "660000" },
+        { name: "Red Berry", hex: "990000" },
+        { name: "Guardsman Red", hex: "cc0000" },
+        { name: "Persian Red", hex: "cc3333" },
+        { name: "French Rose", hex: "ea4c88" },
+        { name: "Plum", hex: "993399" },
+        { name: "Royal Purple", hex: "663399" },
+        { name: "Sapphire", hex: "333399" },
+        { name: "Science Blue", hex: "0066cc" },
+        { name: "Pacific Blue", hex: "0099cc" },
+        { name: "Downy", hex: "66cccc" },
+        { name: "Atlantis", hex: "77cc33" },
+        { name: "Limeade", hex: "669900" },
+        { name: "Verdun Green", hex: "336600" },
+        { name: "Verdun Green 2", hex: "666600" },
+        { name: "Olive", hex: "999900" },
+        { name: "Earls Green", hex: "cccc33" },
+        { name: "Yellow", hex: "ffff00" },
+        { name: "Sunglow", hex: "ffcc33" },
+        { name: "Orange Peel", hex: "ff9900" },
+        { name: "Blaze Orange", hex: "ff6600" },
+        { name: "Tuscany", hex: "cc6633" },
+        { name: "Potters Clay", hex: "996633" },
+        { name: "Nutmeg", hex: "663300" },
+        { name: "Black", hex: "000000" },
+        { name: "Dusty Gray", hex: "999999" },
+        { name: "Silver", hex: "cccccc" },
+        { name: "White", hex: "ffffff" },
+        { name: "Gun Powder", hex: "424153" }
+    ]
+
+    readonly property var resolutionPresets: [
+        { name: "Any", value: "" },
+        { name: "HD", value: "1280x720" },
+        { name: "FHD", value: "1920x1080" },
+        { name: "2K", value: "2560x1440" },
+        { name: "4K", value: "3840x2160" },
+        { name: "5K", value: "5120x2880" },
+        { name: "8K", value: "7680x4320" },
+        { name: "UW FHD", value: "2560x1080" },
+        { name: "UW QHD", value: "3440x1440" }
+    ]
+
+    signal sortingSelected(string value)
+    signal orderSelected(string value)
+    signal topRangeSelected(string value)
+    signal categorySelected(string value)
+    signal colorSelected(string value)
+    signal resolutionSelected(string value)
+
+    spacing: 6
+
+    // Sorting dropdown with order and topRange
+    Rectangle {
+        id: sortingBtn
+        width: sortingText.width + 16
+        height: 28
+        radius: 6
+        color: ThemeManager.selectedTheme?.colors?.leftMenuBgColorV2 || "#222"
+
+        Text {
+            id: sortingText
+            anchors.centerIn: parent
+            text: {
+                const sorts = { "toplist": "Top", "date_added": "New", "random": "Random", "views": "Views", "relevance": "Relevant", "favorites": "Fav" };
+                let label = sorts[root.sorting] || "Top";
+                if (root.sorting === "toplist") {
+                    const range = root.topRangePresets.find(r => r.value === root.topRange);
+                    label += " (" + (range ? range.name : root.topRange) + ")";
+                }
+                label += root.order === "asc" ? " ↑" : " ↓";
+                return label;
+            }
+            font.pixelSize: 11
+            color: ThemeManager.selectedTheme?.colors?.leftMenuFgColorV1 || "#fff"
+        }
+
+        MouseArea {
+            anchors.fill: parent
+            cursorShape: Qt.PointingHandCursor
+            onClicked: sortingPopup.visible ? sortingPopup.close() : sortingPopup.open()
+        }
+
+        Popup {
+            id: sortingPopup
+            x: 0
+            y: -height - 4
+            width: 180
+            padding: 8
+            closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
+
+            background: Rectangle {
+                color: ThemeManager.selectedTheme?.colors?.leftMenuBgColorV1 || "#1a1a2e"
+                radius: 8
+                border.color: ThemeManager.selectedTheme?.colors?.primary.alpha(0.3) || "#444"
+                border.width: 1
+            }
+
+            contentItem: Column {
+                spacing: 6
+
+                Grid {
+                    columns: 3
+                    spacing: 4
+
+                    Repeater {
+                        model: [
+                            { name: "Top", value: "toplist" },
+                            { name: "New", value: "date_added" },
+                            { name: "Random", value: "random" },
+                            { name: "Views", value: "views" },
+                            { name: "Fav", value: "favorites" },
+                            { name: "Relevant", value: "relevance" }
+                        ]
+
+                        Rectangle {
+                            id: sortOptionRect
+                            required property var modelData
+                            width: 52
+                            height: 26
+                            radius: 4
+                            color: root.sorting === sortOptionRect.modelData.value
+                                ? ThemeManager.selectedTheme?.colors?.primary.alpha(0.3) || "#333"
+                                : ThemeManager.selectedTheme?.colors?.leftMenuBgColorV2 || "#222"
+                            border.color: root.sorting === sortOptionRect.modelData.value
+                                ? ThemeManager.selectedTheme?.colors?.primary || "#6366f1"
+                                : "transparent"
+                            border.width: 1
+
+                            Text {
+                                anchors.centerIn: parent
+                                text: sortOptionRect.modelData.name
+                                font.pixelSize: 10
+                                color: root.sorting === sortOptionRect.modelData.value
+                                    ? ThemeManager.selectedTheme?.colors?.primary || "#6366f1"
+                                    : ThemeManager.selectedTheme?.colors?.leftMenuFgColorV1 || "#fff"
+                            }
+
+                            MouseArea {
+                                anchors.fill: parent
+                                cursorShape: Qt.PointingHandCursor
+                                onClicked: root.sortingSelected(sortOptionRect.modelData.value)
+                            }
+                        }
+                    }
+                }
+
+                Row {
+                    spacing: 4
+
+                    Repeater {
+                        model: [
+                            { name: "Desc ↓", value: "desc" },
+                            { name: "Asc ↑", value: "asc" }
+                        ]
+
+                        Rectangle {
+                            id: orderRect
+                            required property var modelData
+                            width: 80
+                            height: 26
+                            radius: 4
+                            color: root.order === orderRect.modelData.value
+                                ? ThemeManager.selectedTheme?.colors?.primary.alpha(0.3) || "#333"
+                                : ThemeManager.selectedTheme?.colors?.leftMenuBgColorV2 || "#222"
+                            border.color: root.order === orderRect.modelData.value
+                                ? ThemeManager.selectedTheme?.colors?.primary || "#6366f1"
+                                : "transparent"
+                            border.width: 1
+
+                            Text {
+                                anchors.centerIn: parent
+                                text: orderRect.modelData.name
+                                font.pixelSize: 10
+                                color: root.order === orderRect.modelData.value
+                                    ? ThemeManager.selectedTheme?.colors?.primary || "#6366f1"
+                                    : ThemeManager.selectedTheme?.colors?.leftMenuFgColorV1 || "#fff"
+                            }
+
+                            MouseArea {
+                                anchors.fill: parent
+                                cursorShape: Qt.PointingHandCursor
+                                onClicked: root.orderSelected(orderRect.modelData.value)
+                            }
+                        }
+                    }
+                }
+
+                Column {
+                    spacing: 4
+                    visible: root.sorting === "toplist"
+
+                    Rectangle {
+                        width: 164
+                        height: 1
+                        color: ThemeManager.selectedTheme?.colors?.primary.alpha(0.2) || "#333"
+                    }
+
+                    Text {
+                        text: "Time Range"
+                        font.pixelSize: 9
+                        color: ThemeManager.selectedTheme?.colors?.subtleText || "#888"
+                    }
+
+                    Grid {
+                        columns: 2
+                        spacing: 4
+
+                        Repeater {
+                            model: root.topRangePresets
+
+                            Rectangle {
+                                id: rangeRect
+                                required property var modelData
+                                width: 78
+                                height: 24
+                                radius: 4
+                                color: root.topRange === rangeRect.modelData.value
+                                    ? ThemeManager.selectedTheme?.colors?.primary.alpha(0.3) || "#333"
+                                    : ThemeManager.selectedTheme?.colors?.leftMenuBgColorV2 || "#222"
+                                border.color: root.topRange === rangeRect.modelData.value
+                                    ? ThemeManager.selectedTheme?.colors?.primary || "#6366f1"
+                                    : "transparent"
+                                border.width: 1
+
+                                Text {
+                                    anchors.centerIn: parent
+                                    text: rangeRect.modelData.name
+                                    font.pixelSize: 10
+                                    color: root.topRange === rangeRect.modelData.value
+                                        ? ThemeManager.selectedTheme?.colors?.primary || "#6366f1"
+                                        : ThemeManager.selectedTheme?.colors?.leftMenuFgColorV1 || "#fff"
+                                }
+
+                                MouseArea {
+                                    anchors.fill: parent
+                                    cursorShape: Qt.PointingHandCursor
+                                    onClicked: root.topRangeSelected(rangeRect.modelData.value)
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Categories dropdown
+    Rectangle {
+        id: categoriesBtn
+        width: catBtnText.width + 16
+        height: 28
+        radius: 6
+        color: ThemeManager.selectedTheme?.colors?.leftMenuBgColorV2 || "#222"
+
+        Text {
+            id: catBtnText
+            anchors.centerIn: parent
+            text: "Categories"
+            font.pixelSize: 11
+            color: ThemeManager.selectedTheme?.colors?.leftMenuFgColorV1 || "#fff"
+        }
+
+        MouseArea {
+            anchors.fill: parent
+            cursorShape: Qt.PointingHandCursor
+            onClicked: categoriesPopup.visible ? categoriesPopup.close() : categoriesPopup.open()
+        }
+
+        Popup {
+            id: categoriesPopup
+            x: 0
+            y: -height - 4
+            padding: 8
+            closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
+
+            background: Rectangle {
+                color: ThemeManager.selectedTheme?.colors?.leftMenuBgColorV1 || "#1a1a2e"
+                radius: 8
+                border.color: ThemeManager.selectedTheme?.colors?.primary.alpha(0.3) || "#444"
+                border.width: 1
+            }
+
+            contentItem: Column {
+                spacing: 4
+
+                Repeater {
+                    model: [
+                        { label: "General", mask: 0 },
+                        { label: "Anime", mask: 1 },
+                        { label: "People", mask: 2 }
+                    ]
+
+                    Rectangle {
+                        id: catPopupRect
+                        required property var modelData
+                        property bool isOn: root.category.charAt(catPopupRect.modelData.mask) === "1"
+                        
+                        width: 100
+                        height: 28
+                        radius: 4
+                        color: catPopupRect.isOn
+                            ? ThemeManager.selectedTheme?.colors?.primary.alpha(0.3) || "#333"
+                            : ThemeManager.selectedTheme?.colors?.leftMenuBgColorV2 || "#222"
+                        border.color: catPopupRect.isOn
+                            ? ThemeManager.selectedTheme?.colors?.primary || "#6366f1"
+                            : "transparent"
+                        border.width: 1
+
+                        Row {
+                            anchors.centerIn: parent
+                            spacing: 6
+
+                            Rectangle {
+                                width: 14
+                                height: 14
+                                radius: 3
+                                anchors.verticalCenter: parent.verticalCenter
+                                color: catPopupRect.isOn 
+                                    ? ThemeManager.selectedTheme?.colors?.primary || "#6366f1"
+                                    : "transparent"
+                                border.color: ThemeManager.selectedTheme?.colors?.primary || "#6366f1"
+                                border.width: 1
+
+                                Text {
+                                    anchors.centerIn: parent
+                                    text: catPopupRect.isOn ? "✓" : ""
+                                    font.pixelSize: 10
+                                    color: "#fff"
+                                }
+                            }
+
+                            Text {
+                                text: catPopupRect.modelData.label
+                                font.pixelSize: 11
+                                anchors.verticalCenter: parent.verticalCenter
+                                color: catPopupRect.isOn
+                                    ? ThemeManager.selectedTheme?.colors?.primary || "#6366f1"
+                                    : ThemeManager.selectedTheme?.colors?.leftMenuFgColorV1 || "#fff"
+                            }
+                        }
+
+                        MouseArea {
+                            anchors.fill: parent
+                            cursorShape: Qt.PointingHandCursor
+                            onClicked: {
+                                let cats = root.category.split("");
+                                cats[catPopupRect.modelData.mask] = cats[catPopupRect.modelData.mask] === "1" ? "0" : "1";
+                                if (cats.join("") !== "000") {
+                                    root.categorySelected(cats.join(""));
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Color filter
+    Rectangle {
+        id: colorFilterBtn
+        height: 28
+        width: colorFilterRow.width + 12
+        radius: 6
+        color: ThemeManager.selectedTheme?.colors?.leftMenuBgColorV2 || "#222"
+        border.color: root.color !== "" ? ThemeManager.selectedTheme?.colors?.primary || "#6366f1" : "transparent"
+        border.width: 1
+
+        Row {
+            id: colorFilterRow
+            anchors.centerIn: parent
+            spacing: 4
+
+            Rectangle {
+                width: 14
+                height: 14
+                radius: 7
+                anchors.verticalCenter: parent.verticalCenter
+                color: root.color !== "" ? ("#" + root.color) : "transparent"
+                border.color: root.color === "" 
+                    ? ThemeManager.selectedTheme?.colors?.subtleText || "#666" 
+                    : "transparent"
+                border.width: 1
+
+                Text {
+                    anchors.centerIn: parent
+                    text: root.color === "" ? "?" : ""
+                    font.pixelSize: 9
+                    color: ThemeManager.selectedTheme?.colors?.subtleText || "#888"
+                }
+            }
+
+            Text {
+                text: root.color === "" ? "Color" : root.colorPresets.find(c => c.hex === root.color)?.name || "Custom"
+                font.pixelSize: 11
+                anchors.verticalCenter: parent.verticalCenter
+                color: root.color !== ""
+                    ? ThemeManager.selectedTheme?.colors?.primary || "#6366f1"
+                    : ThemeManager.selectedTheme?.colors?.subtleText || "#888"
+            }
+        }
+
+        MouseArea {
+            anchors.fill: parent
+            cursorShape: Qt.PointingHandCursor
+            onClicked: colorPopup.open()
+        }
+
+        Popup {
+            id: colorPopup
+            x: 0
+            y: parent.height + 4
+            width: 220
+            padding: 8
+
+            background: Rectangle {
+                color: ThemeManager.selectedTheme?.colors?.leftMenuBgColorV1 || "#1a1a2e"
+                radius: 8
+                border.color: ThemeManager.selectedTheme?.colors?.primary.alpha(0.3) || "#444"
+                border.width: 1
+            }
+
+            contentItem: Grid {
+                columns: 6
+                spacing: 4
+
+                Repeater {
+                    model: root.colorPresets
+
+                    Rectangle {
+                        id: colorPresetRect
+                        required property var modelData
+                        required property int index
+
+                        width: 32
+                        height: 24
+                        radius: 4
+                        color: colorPresetRect.modelData.hex === "" 
+                            ? ThemeManager.selectedTheme?.colors?.leftMenuBgColorV2 || "#333"
+                            : ("#" + colorPresetRect.modelData.hex)
+                        border.color: root.color === colorPresetRect.modelData.hex
+                            ? ThemeManager.selectedTheme?.colors?.primary || "#6366f1"
+                            : (colorPresetRect.modelData.hex === "ffffff" || colorPresetRect.modelData.hex === "cccccc" ? "#999" : "transparent")
+                        border.width: root.color === colorPresetRect.modelData.hex ? 2 : 1
+
+                        Text {
+                            anchors.centerIn: parent
+                            text: colorPresetRect.modelData.hex === "" ? "✕" : ""
+                            font.pixelSize: 12
+                            color: ThemeManager.selectedTheme?.colors?.subtleText || "#888"
+                        }
+
+                        ToolTip.visible: colorPresetMouse.containsMouse
+                        ToolTip.text: colorPresetRect.modelData.name
+                        ToolTip.delay: 500
+
+                        MouseArea {
+                            id: colorPresetMouse
+                            anchors.fill: parent
+                            hoverEnabled: true
+                            cursorShape: Qt.PointingHandCursor
+                            onClicked: {
+                                root.colorSelected(colorPresetRect.modelData.hex);
+                                colorPopup.close();
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Resolution filter
+    Rectangle {
+        id: resFilterBtn
+        height: 28
+        width: resFilterText.width + 12
+        radius: 6
+        color: ThemeManager.selectedTheme?.colors?.leftMenuBgColorV2 || "#222"
+        border.color: root.resolution !== "" ? ThemeManager.selectedTheme?.colors?.primary || "#6366f1" : "transparent"
+        border.width: 1
+
+        Text {
+            id: resFilterText
+            anchors.centerIn: parent
+            text: root.resolution === "" ? "Resolution" : root.resolutionPresets.find(r => r.value === root.resolution)?.name || root.resolution
+            font.pixelSize: 11
+            color: root.resolution !== ""
+                ? ThemeManager.selectedTheme?.colors?.primary || "#6366f1"
+                : ThemeManager.selectedTheme?.colors?.subtleText || "#888"
+        }
+
+        MouseArea {
+            anchors.fill: parent
+            cursorShape: Qt.PointingHandCursor
+            onClicked: resPopup.open()
+        }
+
+        Popup {
+            id: resPopup
+            x: 0
+            y: parent.height + 4
+            width: 120
+            padding: 8
+
+            background: Rectangle {
+                color: ThemeManager.selectedTheme?.colors?.leftMenuBgColorV1 || "#1a1a2e"
+                radius: 8
+                border.color: ThemeManager.selectedTheme?.colors?.primary.alpha(0.3) || "#444"
+                border.width: 1
+            }
+
+            contentItem: Column {
+                spacing: 4
+
+                Repeater {
+                    model: root.resolutionPresets
+
+                    Rectangle {
+                        id: resPresetRect
+                        required property var modelData
+                        required property int index
+
+                        width: 104
+                        height: 28
+                        radius: 6
+                        color: root.resolution === resPresetRect.modelData.value
+                            ? ThemeManager.selectedTheme?.colors?.primary.alpha(0.2) || "#333"
+                            : resPresetMouse.containsMouse
+                                ? ThemeManager.selectedTheme?.colors?.primary.alpha(0.1) || "#222"
+                                : "transparent"
+                        border.color: root.resolution === resPresetRect.modelData.value
+                            ? ThemeManager.selectedTheme?.colors?.primary || "#6366f1"
+                            : "transparent"
+                        border.width: 1
+
+                        Text {
+                            anchors.centerIn: parent
+                            text: resPresetRect.modelData.name + (resPresetRect.modelData.value !== "" ? "+" : "")
+                            font.pixelSize: 11
+                            color: root.resolution === resPresetRect.modelData.value
+                                ? ThemeManager.selectedTheme?.colors?.primary || "#6366f1"
+                                : ThemeManager.selectedTheme?.colors?.leftMenuFgColorV1 || "#fff"
+                        }
+
+                        MouseArea {
+                            id: resPresetMouse
+                            anchors.fill: parent
+                            hoverEnabled: true
+                            cursorShape: Qt.PointingHandCursor
+                            onClicked: {
+                                root.resolutionSelected(resPresetRect.modelData.value);
+                                resPopup.close();
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/config/quickshell/components/wallpaper_selector/WallpaperCard.qml
+++ b/config/quickshell/components/wallpaper_selector/WallpaperCard.qml
@@ -1,0 +1,140 @@
+// components/wallpaper_selector/WallpaperCard.qml
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Layouts
+
+import "root:/themes"
+
+Item {
+    id: root
+
+    required property var modelData
+    required property int index
+    property bool isWallhaven: false
+    property string currentWallpaper: ""
+
+    signal clicked(var wallpaperData)
+
+    property string thumbUrl: {
+        if (!modelData) return "";
+        return isWallhaven ? (modelData.thumb || "") : ("file://" + modelData);
+    }
+    property string wallpaperPath: {
+        if (!modelData) return "";
+        return isWallhaven ? (modelData.path || "") : modelData;
+    }
+    property string displayName: {
+        if (!modelData) return "";
+        if (isWallhaven) {
+            return modelData.resolution || modelData.id || "";
+        }
+        return typeof modelData === 'string' ? modelData.split('/').pop() : "";
+    }
+
+    Rectangle {
+        id: cardBg
+        anchors.fill: parent
+        anchors.margins: 4
+        radius: ThemeManager.selectedTheme?.dimensions?.elementRadius || 8
+        color: itemMouseArea.containsMouse 
+            ? ThemeManager.selectedTheme?.colors?.primary.alpha(0.15) || "#333"
+            : "transparent"
+        border.color: root.currentWallpaper === root.wallpaperPath
+            ? ThemeManager.selectedTheme?.colors?.primary || "#6366f1"
+            : itemMouseArea.containsMouse 
+                ? ThemeManager.selectedTheme?.colors?.primary.alpha(0.5) || "#555"
+                : "transparent"
+        border.width: root.currentWallpaper === root.wallpaperPath ? 2 : 1
+
+        Behavior on color {
+            ColorAnimation { duration: 150 }
+        }
+
+        ColumnLayout {
+            anchors.fill: parent
+            anchors.margins: 4
+            spacing: 4
+
+            Rectangle {
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                radius: (ThemeManager.selectedTheme?.dimensions?.elementRadius || 8) - 2
+                color: ThemeManager.selectedTheme?.colors?.leftMenuBgColorV1 || "#111"
+                clip: true
+
+                Image {
+                    id: thumbImage
+                    anchors.fill: parent
+                    source: root.thumbUrl
+                    fillMode: Image.PreserveAspectCrop
+                    asynchronous: true
+                    sourceSize: Qt.size(300, 200)
+                }
+
+                // Loading indicator
+                Rectangle {
+                    anchors.centerIn: parent
+                    width: 24
+                    height: 24
+                    radius: 12
+                    color: ThemeManager.selectedTheme?.colors?.primary.alpha(0.3) || "#333"
+                    visible: thumbImage.status === Image.Loading
+
+                    Text {
+                        anchors.centerIn: parent
+                        text: "󰑐"
+                        font.pixelSize: 14
+                        font.family: ThemeManager.selectedTheme?.typography?.iconFont || "Material Design Icons"
+                        color: ThemeManager.selectedTheme?.colors?.primary || "#6366f1"
+
+                        RotationAnimation on rotation {
+                            running: thumbImage.status === Image.Loading
+                            from: 0
+                            to: 360
+                            duration: 1000
+                            loops: Animation.Infinite
+                        }
+                    }
+                }
+
+                // Wallhaven badge
+                Rectangle {
+                    anchors.top: parent.top
+                    anchors.left: parent.left
+                    anchors.margins: 4
+                    height: 16
+                    width: favText.width + 8
+                    radius: 4
+                    color: "#000000aa"
+                    visible: root.isWallhaven && root.modelData && (root.modelData.favorites || 0) > 0
+
+                    Text {
+                        id: favText
+                        anchors.centerIn: parent
+                        text: "♥ " + (root.modelData && root.modelData.favorites ? root.modelData.favorites : 0)
+                        font.pixelSize: 9
+                        color: "#ff6b6b"
+                    }
+                }
+            }
+
+            Text {
+                Layout.fillWidth: true
+                text: root.displayName
+                font.pixelSize: 10
+                color: ThemeManager.selectedTheme?.colors?.subtleText || "#888"
+                elide: Text.ElideMiddle
+                horizontalAlignment: Text.AlignHCenter
+            }
+        }
+
+        MouseArea {
+            id: itemMouseArea
+            anchors.fill: parent
+            hoverEnabled: true
+            cursorShape: Qt.PointingHandCursor
+            onClicked: root.clicked(root.modelData)
+        }
+    }
+}

--- a/config/quickshell/components/wallpaper_selector/WallpaperGrid.qml
+++ b/config/quickshell/components/wallpaper_selector/WallpaperGrid.qml
@@ -1,0 +1,116 @@
+// components/wallpaper_selector/WallpaperGrid.qml
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Controls
+
+import "root:/themes"
+
+Rectangle {
+    id: root
+
+    property var wallpapers: []
+    property bool isWallhaven: false
+    property bool loading: false
+    property bool compact: false
+    property string currentWallpaper: ""
+    property string emptyText: qsTr("No wallpapers found")
+
+    signal wallpaperClicked(var wallpaperData)
+    signal loadMore
+
+    radius: ThemeManager.selectedTheme?.dimensions?.elementRadius || 8
+    color: ThemeManager.selectedTheme?.colors?.leftMenuBgColorV2 || "#1a1a2e"
+    clip: true
+
+    GridView {
+        id: wallpaperGrid
+        anchors.fill: parent
+        anchors.margins: 8
+
+        property int columns: root.compact ? 1 : 4
+        cellWidth: (width - 16) / columns
+        cellHeight: root.compact ? cellWidth * 0.5 + 24 : cellWidth * 0.6 + 28
+
+        model: root.wallpapers
+        clip: true
+        boundsBehavior: Flickable.StopAtBounds
+
+        ScrollBar.vertical: ScrollBar {
+            active: true
+            policy: ScrollBar.AsNeeded
+        }
+
+        onAtYEndChanged: {
+            if (atYEnd && root.isWallhaven && !root.loading) {
+                root.loadMore();
+            }
+        }
+
+        delegate: WallpaperCard {
+            width: wallpaperGrid.cellWidth
+            height: wallpaperGrid.cellHeight
+            
+            isWallhaven: root.isWallhaven
+            currentWallpaper: root.currentWallpaper
+
+            onClicked: wallpaperData => root.wallpaperClicked(wallpaperData)
+        }
+    }
+
+    // Empty state
+    Text {
+        anchors.centerIn: parent
+        visible: root.wallpapers.length === 0 && !root.loading
+        text: root.emptyText
+        font.pixelSize: 14
+        color: ThemeManager.selectedTheme?.colors?.subtleText || "#888"
+        horizontalAlignment: Text.AlignHCenter
+    }
+
+    // Loading state
+    Rectangle {
+        anchors.centerIn: parent
+        width: 48
+        height: 48
+        radius: 24
+        color: ThemeManager.selectedTheme?.colors?.primary.alpha(0.2) || "#333"
+        visible: root.loading && root.wallpapers.length === 0
+
+        Text {
+            anchors.centerIn: parent
+            text: "󰑐"
+            font.pixelSize: 24
+            font.family: ThemeManager.selectedTheme?.typography?.iconFont || "Material Design Icons"
+            color: ThemeManager.selectedTheme?.colors?.primary || "#6366f1"
+
+            RotationAnimation on rotation {
+                running: root.loading
+                from: 0
+                to: 360
+                duration: 1000
+                loops: Animation.Infinite
+            }
+        }
+    }
+
+    // Load more indicator
+    Rectangle {
+        anchors.bottom: parent.bottom
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.bottomMargin: 8
+        width: loadMoreText.width + 24
+        height: 28
+        radius: 14
+        color: ThemeManager.selectedTheme?.colors?.primary.alpha(0.9) || "#6366f1"
+        visible: root.isWallhaven && root.loading && root.wallpapers.length > 0
+
+        Text {
+            id: loadMoreText
+            anchors.centerIn: parent
+            text: "Loading more..."
+            font.pixelSize: 11
+            color: "#fff"
+        }
+    }
+}

--- a/config/quickshell/components/wallpaper_selector/WallpaperHeader.qml
+++ b/config/quickshell/components/wallpaper_selector/WallpaperHeader.qml
@@ -1,0 +1,103 @@
+// components/wallpaper_selector/WallpaperHeader.qml
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Layouts
+import "root:/themes"
+
+RowLayout {
+    id: root
+
+    property bool isLoading: false
+    property int sourceMode: 0
+
+    signal refreshClicked
+    signal closeClicked
+
+    spacing: 12
+
+    Text {
+        text: "󰸉"
+        font.pixelSize: 24
+        font.family: ThemeManager.selectedTheme?.typography?.iconFont || "Material Design Icons"
+        color: ThemeManager.selectedTheme?.colors?.primary || "#fff"
+    }
+
+    ColumnLayout {
+        Layout.fillWidth: true
+        spacing: 2
+
+        Text {
+            text: qsTr("Wallpaper Selector")
+            font.pixelSize: 16
+            font.bold: true
+            color: ThemeManager.selectedTheme?.colors?.leftMenuFgColorV1 || "#fff"
+        }
+
+        Text {
+            text: root.sourceMode === 2 ? qsTr("Browse wallpapers from Wallhaven.cc") : qsTr("Select a wallpaper to apply")
+            font.pixelSize: 11
+            color: ThemeManager.selectedTheme?.colors?.subtleText || "#888"
+        }
+    }
+
+    // Refresh button
+    Rectangle {
+        width: 28
+        height: 28
+        radius: 6
+        color: refreshMouseArea.containsMouse 
+            ? ThemeManager.selectedTheme?.colors?.primary.alpha(0.2) || "#333"
+            : "transparent"
+
+        Text {
+            anchors.centerIn: parent
+            text: root.isLoading ? "󰦖" : "󰑐"
+            font.pixelSize: 16
+            font.family: ThemeManager.selectedTheme?.typography?.iconFont || "Material Design Icons"
+            color: ThemeManager.selectedTheme?.colors?.subtleText || "#888"
+
+            RotationAnimation on rotation {
+                running: root.isLoading
+                from: 0
+                to: 360
+                duration: 1000
+                loops: Animation.Infinite
+            }
+        }
+
+        MouseArea {
+            id: refreshMouseArea
+            anchors.fill: parent
+            hoverEnabled: true
+            cursorShape: Qt.PointingHandCursor
+            onClicked: root.refreshClicked()
+        }
+    }
+
+    // Close button
+    Rectangle {
+        width: 28
+        height: 28
+        radius: 6
+        color: closeMouseArea.containsMouse 
+            ? ThemeManager.selectedTheme?.colors?.primary.alpha(0.2) || "#333"
+            : "transparent"
+
+        Text {
+            anchors.centerIn: parent
+            text: "󰅖"
+            font.pixelSize: 16
+            font.family: ThemeManager.selectedTheme?.typography?.iconFont || "Material Design Icons"
+            color: ThemeManager.selectedTheme?.colors?.subtleText || "#888"
+        }
+
+        MouseArea {
+            id: closeMouseArea
+            anchors.fill: parent
+            hoverEnabled: true
+            cursorShape: Qt.PointingHandCursor
+            onClicked: root.closeClicked()
+        }
+    }
+}

--- a/config/quickshell/config/App.qml
+++ b/config/quickshell/config/App.qml
@@ -69,6 +69,9 @@ Singleton {
     property alias cpuHighLoadThreshold: root.config.cpuHighLoadThreshold
     property alias ramHighLoadThreshold: root.config.ramHighLoadThreshold
 
+    property alias useBottomLauncher: root.config.useBottomLauncher
+    property alias bottomLauncherWidth: root.config.bottomLauncherWidth
+
     function updateConfig(key, value) {
         root.config.set(key, value);
     }

--- a/config/quickshell/config/App.qml
+++ b/config/quickshell/config/App.qml
@@ -17,6 +17,7 @@ Singleton {
     readonly property string bashScriptsPath: mainPath + "/scripts"
     readonly property string wallpapersPath: assetsPath + "/wallpapers"
     readonly property string cacheFolderPath: homePath + ".cache/nibrasshell"
+    readonly property string downloadedWallpapersPath: cacheFolderPath + "/wallpapers"
     readonly property string themeCacheFilePath: cacheFolderPath + "/theme.json"
     readonly property string themeCacheFolderPath: cacheFolderPath + "/themes/"
     readonly property string pythonScriptsPath: mainPath + "/scripts/python"
@@ -254,6 +255,10 @@ Singleton {
             readonly property var cpuCommand: ["sh", "-c", cpuUsage]
             readonly property var ramCommand: ["sh", "-c", ramUsage]
             readonly property var deviceTempretureCommand: ["sh", "-c", deviceTempreture]
+
+            function downloadWallpaperCommand(destPath, url) {
+                return ["sh", "-c", "mkdir -p '" + root.downloadedWallpapersPath + "' && curl -s -L -o '" + destPath + "' '" + url + "'"];
+            }
         }
     }
 

--- a/config/quickshell/config/CommandsRegistry.qml
+++ b/config/quickshell/config/CommandsRegistry.qml
@@ -1,0 +1,51 @@
+// config/CommandsRegistry.qml
+pragma Singleton
+
+import QtQuick
+import Quickshell
+
+Singleton {
+    id: root
+
+    // All available launcher commands
+    readonly property var commands: [
+        { 
+            name: "Change Wallpaper", 
+            keywords: "wallpaper background",
+            description: "Browse and set wallpapers", 
+            icon: "󰸉", 
+            view: "wallpaper", 
+            isAction: false 
+        },
+        { 
+            name: "Open Settings", 
+            keywords: "settings preferences config",
+            description: "Configure nibras-shell options", 
+            icon: "󰒓", 
+            view: "", 
+            isAction: true,
+            action: "openSettings"
+        }
+    ]
+
+    // Filter commands by search text
+    function filterCommands(searchText) {
+        if (!searchText || searchText === "") return commands;
+        const lower = searchText.toLowerCase();
+        return commands.filter(cmd => 
+            cmd.name.toLowerCase().includes(lower) || 
+            cmd.keywords.toLowerCase().includes(lower)
+        );
+    }
+
+    // Check if text starts with command prefix
+    function isCommandMode(text) {
+        return text && text.length > 0 && text.charAt(0) === ">";
+    }
+
+    // Extract command text (without the > prefix)
+    function getCommandText(text) {
+        if (!isCommandMode(text) || text.length <= 1) return "";
+        return text.substring(1).trim().toLowerCase();
+    }
+}

--- a/config/quickshell/config/ConfigStore.qml
+++ b/config/quickshell/config/ConfigStore.qml
@@ -43,6 +43,9 @@ QtObject {
     property int cpuHighLoadThreshold: 85
     property int ramHighLoadThreshold: 85
 
+    property bool useBottomLauncher: false  // false = side launcher, true = bottom launcher
+    property int bottomLauncherWidth: 800
+
     property var _fileView: FileView {
         id: fileWatcher
         path: Qt.resolvedUrl(store.configPath)
@@ -144,6 +147,11 @@ QtObject {
             store.cpuHighLoadThreshold = data.cpuHighLoadThreshold;
         if (data.ramHighLoadThreshold !== undefined)
             store.ramHighLoadThreshold = data.ramHighLoadThreshold;
+
+        if (data.useBottomLauncher !== undefined)
+            store.useBottomLauncher = data.useBottomLauncher;
+        if (data.bottomLauncherWidth !== undefined)
+            store.bottomLauncherWidth = data.bottomLauncherWidth;
 
         store.settingsLoaded();
         console.info("Config reloaded successfully.");

--- a/config/quickshell/config/EventNames.js
+++ b/config/quickshell/config/EventNames.js
@@ -16,3 +16,5 @@ var OPEN_CHEATSHEET = "openCheatsheet";
 
 var CPU_THRESHOLD_EXCEEDED = "cpuThresholdExceeded";
 var MEMORY_THRESHOLD_EXCEEDED = "memoryThresholdExceeded";
+
+var TOGGLE_BOTTOM_LAUNCHER = "toggleBottomLauncher";

--- a/config/quickshell/shell.qml
+++ b/config/quickshell/shell.qml
@@ -11,6 +11,7 @@ import "root:/windows/leftwindow"
 import "root:/windows/smart_capsule"
 import "root:/windows/settings"
 import "root:/windows/cheatsheet"
+import "root:/windows/bottomlauncher"
 import "root:/bars"
 import "root:/osd"
 import "root:/utils"
@@ -235,6 +236,9 @@ ShellRoot {
             Cheatsheet {
                 id: cheatsheetPanel
             }
+            BottomAppLauncher {
+                id: bottomLauncherPanel
+            }
 
             // 5. IPC Handler (Refactored Logic)
             IpcHandler {
@@ -277,7 +281,11 @@ ShellRoot {
                     toggleMenu(Consts.AI_BOT_MENU_INDEX);
                 }
                 function toggleApplauncherMenu() {
-                    toggleMenu(Consts.APPLICATIONS_MENU_INDEX);
+                    if (App.useBottomLauncher) {
+                        bottomLauncherPanel.toggle();
+                    } else {
+                        toggleMenu(Consts.APPLICATIONS_MENU_INDEX);
+                    }
                 }
             }
         }

--- a/config/quickshell/shell.qml
+++ b/config/quickshell/shell.qml
@@ -240,6 +240,16 @@ ShellRoot {
                 id: bottomLauncherPanel
             }
 
+            // Event listener for bottom launcher toggle from LeftBar
+            Connections {
+                target: null
+                Component.onCompleted: {
+                    EventBus.on(Events.TOGGLE_BOTTOM_LAUNCHER, () => {
+                        bottomLauncherPanel.toggle();
+                    });
+                }
+            }
+
             // 5. IPC Handler (Refactored Logic)
             IpcHandler {
                 id: handler

--- a/config/quickshell/themes/ThemeManager.qml
+++ b/config/quickshell/themes/ThemeManager.qml
@@ -18,6 +18,9 @@ Singleton {
     property bool _initialReady: false
     readonly property alias selectedTheme: loader.activeThemeInstance
     readonly property alias currentWallpaper: wallpaperCtrl.currentWallpaperPath
+    readonly property alias localWallpapers: wallpaperCtrl.localWallpapersList
+    readonly property alias downloadedWallpapers: wallpaperCtrl.downloadedWallpapersList
+    readonly property alias wallhavenWallpapers: wallpaperCtrl.wallhavenWallpapersList
     readonly property bool isInitialThemeReady: _initialReady
 
     signal selectedThemeUpdated
@@ -25,6 +28,22 @@ Singleton {
     signal wallpaperChanged(string path)
     signal creatingOverlayImageStarted
     signal creatingOverlayImageFinished(string newImagePath)
+
+    // Wallhaven signals (forwarded from WallpaperController)
+    signal fetchingWallhavenWallpapersStarted
+    signal wallhavenWallpapersFetched(var response)
+    signal wallhavenWallpapersError(string errorDetails)
+
+    // Download signals (forwarded from WallpaperController)
+    signal wallpaperDownloadStarted(string filePath)
+    signal wallpaperDownloadFinished(string filePath)
+    signal wallpaperDownloadError(string errorDetails)
+
+    function refreshLocalWallpapers() { wallpaperCtrl.refreshLocalWallpapers(); }
+    function refreshDownloadedWallpapers() { wallpaperCtrl.refreshDownloadedWallpapers(); }
+    function refreshAllWallpaperLists() { wallpaperCtrl.refreshAllWallpaperLists(); }
+    function searchWallhaven(url) { wallpaperCtrl.searchWallhaven(url); }
+    function downloadWallhaven(id, fileType, url) { wallpaperCtrl.downloadWallhaven(id, fileType, url); }
 
     // =========================================================
     // Internal State for Sequence Control
@@ -84,6 +103,12 @@ Singleton {
             }
             root.wallpaperChanged(path);
         }
+        onFetchingWallhavenWallpapersStarted: root.fetchingWallhavenWallpapersStarted()
+        onWallhavenWallpapersFetched: response => root.wallhavenWallpapersFetched(response)
+        onWallhavenWallpapersError: errorDetails => root.wallhavenWallpapersError(errorDetails)
+        onWallpaperDownloadStarted: filePath => root.wallpaperDownloadStarted(filePath)
+        onWallpaperDownloadFinished: filePath => root.wallpaperDownloadFinished(filePath)
+        onWallpaperDownloadError: errorDetails => root.wallpaperDownloadError(errorDetails)
     }
 
     HyprlandBridge {

--- a/config/quickshell/themes/modules/WallpaperController.qml
+++ b/config/quickshell/themes/modules/WallpaperController.qml
@@ -13,6 +13,52 @@ Item {
     property string currentWallpaperPath: ""
     signal wallpaperReady(string path)
 
+    // Wallpaper Lists
+    property var localWallpapersList: []
+    property var downloadedWallpapersList: []
+    property var wallhavenWallpapersList: []
+
+    // Wallhaven signals
+    signal fetchingWallhavenWallpapersStarted
+    signal wallhavenWallpapersFetched(var response)
+    signal wallhavenWallpapersError(string errorDetails)
+
+    // Download signals
+    signal wallpaperDownloadStarted(string filePath)
+    signal wallpaperDownloadFinished(string filePath)
+    signal wallpaperDownloadError(string errorDetails)
+
+    function refreshLocalWallpapers() {
+        localWallpapersProcess.command = Utils.Helper.getWallpapersList(App.wallpapersPath);
+        localWallpapersProcess.running = true;
+    }
+
+    function refreshDownloadedWallpapers() {
+        downloadedWallpapersProcess.command = Utils.Helper.getWallpapersList(App.downloadedWallpapersPath);
+        downloadedWallpapersProcess.running = true;
+    }
+
+    function refreshAllWallpaperLists() {
+        refreshLocalWallpapers();
+        refreshDownloadedWallpapers();
+    }
+
+    function searchWallhaven(url) {
+        fetchingWallhavenWallpapersStarted();
+        wallhavenProcess.command = ["curl", "-s", url];
+        wallhavenProcess.running = true;
+    }
+
+    function downloadWallhaven(id, fileType, url) {
+        const filename = id + "." + fileType.split('/')[1];
+        const filePath = App.downloadedWallpapersPath + "/" + filename;
+        
+        wallpaperDownloadStarted(filePath);
+        wallhavenDownloadProcess.wallpaperPath = filePath;
+        wallhavenDownloadProcess.command = App.scripts.bash.downloadWallpaperCommand(filePath, url);
+        wallhavenDownloadProcess.running = true;
+    }
+
     // =========================================================
     // Configuration
     // =========================================================
@@ -140,9 +186,72 @@ Item {
         }
     }
 
+    Process {
+        id: localWallpapersProcess
+        stdout: StdioCollector {
+            onStreamFinished: {
+                try {
+                    root.localWallpapersList = JSON.parse(this.text) || [];
+                } catch (e) {
+                    console.error("WallpaperController: Failed to parse local wallpapers", e);
+                    root.localWallpapersList = [];
+                }
+            }
+        }
+    }
+
+    Process {
+        id: downloadedWallpapersProcess
+        stdout: StdioCollector {
+            onStreamFinished: {
+                try {
+                    root.downloadedWallpapersList = JSON.parse(this.text) || [];
+                } catch (e) {
+                    console.error("WallpaperController: Failed to parse downloaded wallpapers", e);
+                    root.downloadedWallpapersList = [];
+                }
+            }
+        }
+    }
+
+    Process {
+        id: wallhavenProcess
+        stdout: StdioCollector {
+            onStreamFinished: {
+                try {
+                    const response = JSON.parse(this.text);
+                    root.wallhavenWallpapersFetched(response);
+                } catch (e) {
+                    console.error("WallpaperController: Failed to parse Wallhaven response", e);
+                    root.wallhavenWallpapersError("Failed to parse response: " + e);
+                }
+            }
+        }
+    }
+
+    Process {
+        id: wallhavenDownloadProcess
+        property string wallpaperPath: ""
+        
+        onExited: (exitCode, exitStatus) => {
+            if (exitCode === 0 && wallpaperPath !== "") {
+                // Push to downloaded list
+                root.downloadedWallpapersList = [...root.downloadedWallpapersList, wallpaperPath];
+                root.wallpaperDownloadFinished(wallpaperPath);
+            } else {
+                console.error("WallpaperController: Download failed with exit code", exitCode);
+                root.wallpaperDownloadError("Download failed with exit code " + exitCode);
+            }
+        }
+    }
+
     Timer {
         id: wallpaperTimer
         repeat: true
         onTriggered: root.nextWallpaper()
+    }
+
+    Component.onCompleted: {
+        refreshAllWallpaperLists();
     }
 }

--- a/config/quickshell/windows/bottomlauncher/BottomAppLauncher.qml
+++ b/config/quickshell/windows/bottomlauncher/BottomAppLauncher.qml
@@ -1,0 +1,192 @@
+// windows/bottomlauncher/BottomAppLauncher.qml
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Quickshell
+
+import "root:/themes"
+import "root:/components"
+import "root:/config"
+import "root:/config/EventNames.js" as Events
+
+PanelWindow {
+    id: root
+
+    property bool isShown: false
+
+    color: "transparent"
+    visible: false
+    focusable: true
+
+    exclusionMode: ExclusionMode.Ignore
+
+    anchors {
+        bottom: true
+        left: true
+        right: true
+    }
+
+    implicitHeight: 550
+    
+    margins {
+        bottom: 20
+    }
+    
+    // Fixed width container centered in the window
+
+    // Keyboard shortcut to toggle the launcher
+    NibrasShellShortcut {
+        id: toggleLauncherShortcut
+        name: "toggleBottomLauncher"
+        onPressed: root.toggle()
+    }
+
+    // Toggle visibility
+    function toggle() {
+        isShown = !isShown;
+    }
+
+    function show() {
+        isShown = true;
+    }
+
+    function hide() {
+        isShown = false;
+    }
+
+    onIsShownChanged: {
+        if (isShown) {
+            if (root.visible && contentContainer.opacity > 0) {
+                contentContainer.state = "visible";
+                return;
+            }
+
+            contentContainer.y = 50;
+            contentContainer.opacity = 0;
+
+            root.visible = true;
+            startOpenAnimTimer.restart();
+        } else {
+            startOpenAnimTimer.stop();
+            contentContainer.state = "hidden";
+        }
+    }
+
+    Timer {
+        id: startOpenAnimTimer
+        interval: 30
+        repeat: false
+        onTriggered: {
+            if (root.isShown) {
+                contentContainer.state = "visible";
+                launcherContent.gainFocus();
+            }
+        }
+    }
+
+    // Close when clicking outside
+    MouseArea {
+        anchors.fill: parent
+        onClicked: root.hide()
+        z: -1
+    }
+
+    Rectangle {
+        id: contentContainer
+
+        width: App.bottomLauncherWidth
+        height: parent.height - 10
+
+        anchors.horizontalCenter: parent.horizontalCenter
+
+        radius: ThemeManager.selectedTheme.dimensions.elementRadius * 1.5
+        color: ThemeManager.selectedTheme.colors.leftMenuBgColorV1
+        border.color: ThemeManager.selectedTheme.colors.primary.alpha(0.3)
+        border.width: 1
+
+        layer.enabled: root.visible && opacity < 1
+        layer.smooth: true
+
+        // Shadow effect
+        Rectangle {
+            id: shadowRect
+            anchors.fill: parent
+            anchors.margins: -2
+            z: -1
+            radius: parent.radius + 2
+            color: "transparent"
+            border.color: Qt.rgba(0, 0, 0, 0.3)
+            border.width: 4
+            visible: false
+        }
+
+        LauncherContent {
+            id: launcherContent
+            anchors.fill: parent
+            anchors.margins: ThemeManager.selectedTheme.dimensions.menuWidgetsMargin
+
+            onAppLaunched: {
+                root.hide();
+            }
+        }
+
+        states: [
+            State {
+                name: "visible"
+                PropertyChanges {
+                    target: contentContainer
+                    y: 0
+                    opacity: 1.0
+                }
+            },
+            State {
+                name: "hidden"
+                PropertyChanges {
+                    target: contentContainer
+                    y: 50
+                    opacity: 0.0
+                }
+            }
+        ]
+
+        transitions: [
+            Transition {
+                from: "hidden"
+                to: "visible"
+                ParallelAnimation {
+                    NumberAnimation {
+                        properties: "y"
+                        duration: 350
+                        easing.type: Easing.OutExpo
+                    }
+                    NumberAnimation {
+                        properties: "opacity"
+                        duration: 200
+                        easing.type: Easing.OutQuad
+                    }
+                }
+            },
+            Transition {
+                from: "visible"
+                to: "hidden"
+                SequentialAnimation {
+                    ParallelAnimation {
+                        NumberAnimation {
+                            properties: "y"
+                            duration: 300
+                            easing.type: Easing.InQuad
+                        }
+                        NumberAnimation {
+                            properties: "opacity"
+                            duration: 250
+                            easing.type: Easing.InQuad
+                        }
+                    }
+                    ScriptAction {
+                        script: root.visible = false
+                    }
+                }
+            }
+        ]
+    }
+}

--- a/config/quickshell/windows/bottomlauncher/BottomAppLauncher.qml
+++ b/config/quickshell/windows/bottomlauncher/BottomAppLauncher.qml
@@ -32,8 +32,6 @@ PanelWindow {
         bottom: 20
     }
     
-    // Fixed width container centered in the window
-
     // Keyboard shortcut to toggle the launcher
     NibrasShellShortcut {
         id: toggleLauncherShortcut

--- a/config/quickshell/windows/bottomlauncher/CategoryFilter.qml
+++ b/config/quickshell/windows/bottomlauncher/CategoryFilter.qml
@@ -1,0 +1,88 @@
+// windows/bottomlauncher/CategoryFilter.qml
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+import "root:/themes"
+import "root:/components"
+
+Item {
+    id: root
+    
+    property string selectedCategory: ""
+
+    // Simplified category definitions
+    readonly property var categories: [
+        { label: "All", category: "" },
+        { label: "Dev", category: "Development" },
+        { label: "Games", category: "Game" },
+        { label: "Graphics", category: "Graphics" },
+        { label: "Internet", category: "Network" },
+        { label: "Media", category: "AudioVideo" },
+        { label: "Office", category: "Office" },
+        { label: "System", category: "System" },
+        { label: "Utils", category: "Utility" }
+    ]
+
+    RowLayout {
+        anchors.fill: parent
+        spacing: 6
+
+        Repeater {
+            model: root.categories
+
+            Rectangle {
+                id: categoryBtn
+                Layout.preferredHeight: 28
+                Layout.preferredWidth: categoryText.implicitWidth + 20
+                radius: ThemeManager.selectedTheme.dimensions.elementRadius
+
+                property bool isSelected: root.selectedCategory === modelData.category
+
+                color: isSelected 
+                    ? ThemeManager.selectedTheme.colors.primary
+                    : mouseArea.containsMouse 
+                        ? ThemeManager.selectedTheme.colors.leftMenuBgColorV2
+                        : "transparent"
+
+                border.color: isSelected 
+                    ? ThemeManager.selectedTheme.colors.primary
+                    : ThemeManager.selectedTheme.colors.primary.alpha(0.3)
+                border.width: 1
+
+                Behavior on color {
+                    ColorAnimation { duration: 150; easing.type: Easing.OutQuad }
+                }
+
+                Text {
+                    id: categoryText
+                    anchors.centerIn: parent
+                    text: modelData.label
+                    font.pixelSize: 12
+                    font.weight: categoryBtn.isSelected ? Font.DemiBold : Font.Normal
+                    color: categoryBtn.isSelected 
+                        ? ThemeManager.selectedTheme.colors.onPrimary
+                        : ThemeManager.selectedTheme.colors.leftMenuFgColorV1
+                    
+                    Behavior on color {
+                        ColorAnimation { duration: 150 }
+                    }
+                }
+
+                MouseArea {
+                    id: mouseArea
+                    anchors.fill: parent
+                    hoverEnabled: true
+                    cursorShape: Qt.PointingHandCursor
+
+                    onClicked: {
+                        root.selectedCategory = modelData.category;
+                    }
+                }
+            }
+        }
+
+        // Spacer
+        Item { Layout.fillWidth: true }
+    }
+}

--- a/config/quickshell/windows/bottomlauncher/LauncherAppItem.qml
+++ b/config/quickshell/windows/bottomlauncher/LauncherAppItem.qml
@@ -1,0 +1,198 @@
+// windows/bottomlauncher/LauncherAppItem.qml
+import QtQuick
+import QtQuick.Layouts
+import Quickshell
+
+import "root:/themes"
+
+Item {
+    id: root
+    
+    signal clicked
+    signal hovered
+    
+    property var appData
+    property bool isSelected: false
+    property bool isHighlighted: false
+
+    height: 64
+
+    Rectangle {
+        id: hoverBg
+        anchors.fill: parent
+        radius: ThemeManager.selectedTheme.dimensions.elementRadius
+        
+        color: {
+            if (root.isHighlighted) {
+                return ThemeManager.selectedTheme.colors.primary.alpha(0.25);
+            }
+            if (root.isSelected) {
+                return ThemeManager.selectedTheme.colors.primary.alpha(0.15);
+            }
+            if (mouseArea.containsMouse) {
+                return ThemeManager.selectedTheme.colors.primary.alpha(0.1);
+            }
+            return "transparent";
+        }
+
+        border.color: root.isHighlighted 
+            ? ThemeManager.selectedTheme.colors.primary 
+            : "transparent"
+        border.width: root.isHighlighted ? 1 : 0
+
+        Behavior on color {
+            ColorAnimation {
+                duration: 150
+                easing.type: Easing.OutQuad
+            }
+        }
+
+        Behavior on border.color {
+            ColorAnimation { duration: 150 }
+        }
+    }
+
+    RowLayout {
+        anchors.fill: parent
+        anchors.leftMargin: 12
+        anchors.rightMargin: 12
+        spacing: 12
+
+        // App Icon
+        Rectangle {
+            Layout.preferredWidth: 44
+            Layout.preferredHeight: 44
+            Layout.alignment: Qt.AlignVCenter
+            radius: ThemeManager.selectedTheme.dimensions.elementRadius * 0.8
+            color: ThemeManager.selectedTheme.colors.leftMenuBgColorV2
+
+            Image {
+                id: appIcon
+                anchors.centerIn: parent
+                width: 32
+                height: 32
+                fillMode: Image.PreserveAspectFit
+                source: Quickshell.iconPath(
+                    appData ? appData.icon : "application-x-executable",
+                    "application-x-executable"
+                )
+                transformOrigin: Item.Center
+
+                Behavior on scale {
+                    NumberAnimation {
+                        duration: 150
+                        easing.type: Easing.OutQuad
+                    }
+                }
+            }
+        }
+
+        // App Info
+        ColumnLayout {
+            Layout.fillWidth: true
+            Layout.alignment: Qt.AlignVCenter
+            spacing: 2
+
+            Text {
+                Layout.fillWidth: true
+                text: appData ? appData.name : "Unknown"
+                font.pixelSize: 14
+                font.weight: Font.Medium
+                color: root.isHighlighted 
+                    ? ThemeManager.selectedTheme.colors.primary
+                    : ThemeManager.selectedTheme.colors.leftMenuFgColorV1
+                elide: Text.ElideRight
+                
+                Behavior on color {
+                    ColorAnimation { duration: 150 }
+                }
+            }
+
+            Text {
+                Layout.fillWidth: true
+                text: appData ? (appData.genericName || appData.comment || "") : ""
+                font.pixelSize: 12
+                color: ThemeManager.selectedTheme.colors.subtleText
+                elide: Text.ElideRight
+                visible: text !== ""
+            }
+        }
+
+        // Pin button (optional feature)
+        Rectangle {
+            Layout.preferredWidth: 28
+            Layout.preferredHeight: 28
+            Layout.alignment: Qt.AlignVCenter
+            radius: ThemeManager.selectedTheme.dimensions.elementRadius * 0.6
+            color: pinMouseArea.containsMouse 
+                ? ThemeManager.selectedTheme.colors.primary.alpha(0.2)
+                : "transparent"
+            visible: mouseArea.containsMouse || root.isSelected
+            opacity: visible ? 1 : 0
+
+            Behavior on opacity {
+                NumberAnimation { duration: 150 }
+            }
+
+            Text {
+                anchors.centerIn: parent
+                text: ""
+                font.family: ThemeManager.selectedTheme.typography.iconFont
+                font.pixelSize: 14
+                color: ThemeManager.selectedTheme.colors.subtleText
+            }
+
+            MouseArea {
+                id: pinMouseArea
+                anchors.fill: parent
+                hoverEnabled: true
+                cursorShape: Qt.PointingHandCursor
+                onClicked: {
+                    // TODO: Implement pinning functionality
+                    console.log("Pin app:", appData.name);
+                }
+            }
+        }
+    }
+
+    MouseArea {
+        id: mouseArea
+        anchors.fill: parent
+        hoverEnabled: true
+        cursorShape: Qt.PointingHandCursor
+
+        onClicked: {
+            bounceAnim.restart();
+            root.clicked();
+        }
+
+        onEntered: root.hovered()
+    }
+
+    SequentialAnimation {
+        id: bounceAnim
+        running: false
+        
+        PropertyAnimation {
+            target: appIcon
+            property: "scale"
+            to: 0.85
+            duration: 80
+            easing.type: Easing.InOutQuad
+        }
+        PropertyAnimation {
+            target: appIcon
+            property: "scale"
+            to: 1.1
+            duration: 100
+            easing.type: Easing.OutQuad
+        }
+        PropertyAnimation {
+            target: appIcon
+            property: "scale"
+            to: 1.0
+            duration: 80
+            easing.type: Easing.OutQuad
+        }
+    }
+}

--- a/config/quickshell/windows/bottomlauncher/LauncherContent.qml
+++ b/config/quickshell/windows/bottomlauncher/LauncherContent.qml
@@ -1,0 +1,226 @@
+// windows/bottomlauncher/LauncherContent.qml
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Quickshell
+
+import "root:/themes"
+import "root:/components"
+import "root:/config"
+import "root:/config/EventNames.js" as Events
+
+Item {
+    id: root
+
+    signal appLaunched
+
+    function gainFocus() {
+        forceActiveFocus();
+        focusTimer.start();
+    }
+
+    Keys.onPressed: event => {
+        if (event.key === Qt.Key_Escape) {
+            appLaunched();
+            event.accepted = true;
+            return;
+        }
+
+        if (event.text && !searchField.activeFocus) {
+            searchField.text += event.text;
+            focusTimer.start();
+            event.accepted = true;
+        }
+    }
+
+    Timer {
+        id: focusTimer
+        interval: 10
+        onTriggered: searchField.forceActiveFocus()
+    }
+
+    Timer {
+        id: clearSearchText
+        interval: 100
+        repeat: false
+        onTriggered: {
+            searchField.text = "";
+            categoryFilter.selectedCategory = "";
+        }
+    }
+
+    ScriptModel {
+        id: filteredModel
+
+        values: {
+            const searchText = searchField.text.toLowerCase();
+            const category = categoryFilter.selectedCategory;
+
+            return [...DesktopEntries.applications.values]
+                .filter(app => app && app.name && app.noDisplay !== true)
+                .filter(app => {
+                    if (category !== "") {
+                        const categories = app.categories || [];
+                        const categoryMatch = categories.some(cat => 
+                            cat.toLowerCase().includes(category.toLowerCase())
+                        );
+                        if (!categoryMatch) return false;
+                    }
+
+                    if (searchText === "") return true;
+
+                    const nameMatch = app.name.toLowerCase().includes(searchText);
+                    const commentMatch = (app.comment || "").toLowerCase().includes(searchText);
+                    const genericNameMatch = (app.genericName || "").toLowerCase().includes(searchText);
+                    const categoriesMatch = (app.categories || []).some(cat => 
+                        cat.toLowerCase().includes(searchText)
+                    );
+
+                    return nameMatch || commentMatch || genericNameMatch || categoriesMatch;
+                })
+                .sort((a, b) => a.name.localeCompare(b.name));
+        }
+    }
+
+    // Search Bar
+    RowLayout {
+        id: searchRow
+        anchors.top: parent.top
+        anchors.left: parent.left
+        anchors.right: parent.right
+        height: 40
+        spacing: 8
+
+        EditableField {
+            id: searchField
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+
+            placeholderText: "Search apps... or use > for commands"
+            font.pixelSize: 14
+            horizontalAlignment: Text.AlignLeft
+
+            normalBackground: ThemeManager.selectedTheme.colors.leftMenuBgColorV2
+            normalForeground: ThemeManager.selectedTheme.colors.leftMenuFgColorV1
+            focusedBorderColor: ThemeManager.selectedTheme.colors.primary
+            borderColor: ThemeManager.selectedTheme.colors.primary.alpha(0.3)
+            borderSize: 1
+
+            topLeftRadius: ThemeManager.selectedTheme.dimensions.elementRadius
+            topRightRadius: ThemeManager.selectedTheme.dimensions.elementRadius
+            bottomLeftRadius: ThemeManager.selectedTheme.dimensions.elementRadius
+            bottomRightRadius: ThemeManager.selectedTheme.dimensions.elementRadius
+
+            onAccepted: {
+                if (filteredModel.values.length > 0) {
+                    const firstApp = filteredModel.values[0];
+                    root.launchApp(firstApp.command, firstApp.workingDirectory);
+                }
+            }
+        }
+
+       
+    }
+
+    // Category Filter
+    CategoryFilter {
+        id: categoryFilter
+        anchors.top: searchRow.bottom
+        anchors.topMargin: 8
+        anchors.left: parent.left
+        anchors.right: parent.right
+        height: 32
+    }
+
+    // App List
+    ListView {
+        id: appListView
+        anchors.top: categoryFilter.bottom
+        anchors.topMargin: 8
+        anchors.left: parent.left
+        anchors.right: scrollBarBg.left
+        anchors.rightMargin: 8
+        anchors.bottom: parent.bottom
+
+        model: filteredModel
+        clip: true
+        spacing: 2
+        currentIndex: -1
+        boundsBehavior: Flickable.StopAtBounds
+
+        delegate: LauncherAppItem {
+            width: appListView.width
+            appData: modelData
+            isSelected: appListView.currentIndex === index
+            isHighlighted: index === 0 && searchField.text !== ""
+
+            onClicked: {
+                root.launchApp(modelData.command, modelData.workingDirectory);
+            }
+
+            onHovered: {
+                appListView.currentIndex = index;
+            }
+        }
+
+        Text {
+            anchors.centerIn: parent
+            visible: filteredModel.values.length === 0
+            text: "No applications found"
+            font.pixelSize: 14
+            color: ThemeManager.selectedTheme.colors.subtleText
+        }
+    }
+
+    // Scrollbar
+    Rectangle {
+        id: scrollBarBg
+        anchors.right: parent.right
+        anchors.top: categoryFilter.bottom
+        anchors.topMargin: 8
+        anchors.bottom: parent.bottom
+        width: 6
+        radius: 3
+        color: ThemeManager.selectedTheme.colors.leftMenuBgColorV2
+        visible: appListView.contentHeight > appListView.height
+
+        Rectangle {
+            id: scrollHandle
+            anchors.horizontalCenter: parent.horizontalCenter
+            width: 6
+            radius: 3
+            color: handleMouseArea.containsMouse || handleMouseArea.pressed
+                ? ThemeManager.selectedTheme.colors.primary
+                : ThemeManager.selectedTheme.colors.primary.alpha(0.6)
+
+            y: Math.max(0, Math.min(parent.height - height, appListView.visibleArea.yPosition * parent.height))
+            height: Math.max(30, appListView.visibleArea.heightRatio * parent.height)
+
+            MouseArea {
+                id: handleMouseArea
+                anchors.fill: parent
+                hoverEnabled: true
+                drag.target: parent
+                drag.axis: Drag.YAxis
+                drag.minimumY: 0
+                drag.maximumY: scrollBarBg.height - scrollHandle.height
+
+                onPositionChanged: {
+                    if (drag.active) {
+                        let ratio = scrollHandle.y / (scrollBarBg.height - scrollHandle.height);
+                        appListView.contentY = ratio * (appListView.contentHeight - appListView.height);
+                    }
+                }
+            }
+        }
+    }
+
+    function launchApp(command, workingDirectory) {
+        clearSearchText.start();
+        Quickshell.execDetached({
+            command: command,
+            workingDirectory: workingDirectory
+        });
+        root.appLaunched();
+    }
+}

--- a/config/quickshell/windows/bottomlauncher/LauncherContent.qml
+++ b/config/quickshell/windows/bottomlauncher/LauncherContent.qml
@@ -14,13 +14,65 @@ Item {
 
     signal appLaunched
 
+    // Command mode using shared registry
+    property bool isCommandMode: CommandsRegistry.isCommandMode(searchField.text)
+    property string commandText: CommandsRegistry.getCommandText(searchField.text)
+    property var filteredCommands: isCommandMode ? CommandsRegistry.filterCommands(commandText) : []
+
+    function executeCommand(cmd) {
+        if (cmd.isAction) {
+            // Handle action commands
+            if (cmd.action === "openSettings") {
+                EventBus.emit(Events.OPEN_SETTINGS);
+                root.appLaunched();
+            }
+        } else if (cmd.view !== "") {
+            // Show the command view
+            root.activeCommandView = cmd.view;
+        }
+    }
+
+    // Current command view (empty = none, "wallpaper" = wallpaper selector, etc.)
+    property string activeCommandView: ""
+
+    // Auto-close command view when exiting command mode
+    onIsCommandModeChanged: {
+        if (!isCommandMode && activeCommandView !== "") {
+            activeCommandView = "";
+        }
+    }
+
     function gainFocus() {
         forceActiveFocus();
         focusTimer.start();
     }
 
+    function exitCommandView() {
+        activeCommandView = "";
+        searchField.text = "";
+        searchField.forceActiveFocus();
+    }
+
+    function resetState() {
+        searchField.text = "";
+        activeCommandView = "";
+        categoryFilter.selectedCategory = "";
+    }
+
+    // Reset when parent becomes invisible
+    onVisibleChanged: {
+        if (!visible) {
+            resetState();
+        }
+    }
+
     Keys.onPressed: event => {
         if (event.key === Qt.Key_Escape) {
+            if (activeCommandView !== "") {
+                exitCommandView();
+                event.accepted = true;
+                return;
+            }
             appLaunched();
             event.accepted = true;
             return;
@@ -46,6 +98,7 @@ Item {
         onTriggered: {
             searchField.text = "";
             categoryFilter.selectedCategory = "";
+            root.activeCommandView = "";
         }
     }
 
@@ -112,6 +165,13 @@ Item {
             bottomRightRadius: ThemeManager.selectedTheme.dimensions.elementRadius
 
             onAccepted: {
+                // Handle command mode
+                if (root.isCommandMode && root.filteredCommands.length > 0) {
+                    const cmd = root.filteredCommands[0];
+                    root.executeCommand(cmd);
+                    return;
+                }
+
                 if (filteredModel.values.length > 0) {
                     const firstApp = filteredModel.values[0];
                     root.launchApp(firstApp.command, firstApp.workingDirectory);
@@ -130,6 +190,57 @@ Item {
         anchors.left: parent.left
         anchors.right: parent.right
         height: 32
+        visible: !root.isCommandMode && root.activeCommandView === ""
+    }
+
+    // Command suggestions list (shows when typing commands with >)
+    ListView {
+        id: commandListView
+        anchors.top: searchRow.bottom
+        anchors.topMargin: 8
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.bottom: parent.bottom
+        visible: root.isCommandMode && root.activeCommandView === ""
+
+        model: root.filteredCommands
+        clip: true
+        spacing: 4
+
+        delegate: CommandItem {
+            width: commandListView.width
+            commandData: modelData
+            isHighlighted: index === 0
+            onClicked: root.executeCommand(modelData)
+        }
+
+        Text {
+            anchors.centerIn: parent
+            visible: root.filteredCommands.length === 0
+            text: "No commands found"
+            font.pixelSize: 14
+            color: ThemeManager.selectedTheme.colors.subtleText
+        }
+    }
+
+    // Wallpaper Selector View
+    WallpaperSelector {
+        id: wallpaperSelector
+        anchors.top: searchRow.bottom
+        anchors.topMargin: 8
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.bottom: parent.bottom
+        visible: root.activeCommandView === "wallpaper"
+
+        onWallpaperSelected: path => {
+            root.exitCommandView();
+            root.appLaunched();
+        }
+
+        onCloseRequested: {
+            root.exitCommandView();
+        }
     }
 
     // App List
@@ -141,6 +252,7 @@ Item {
         anchors.right: scrollBarBg.left
         anchors.rightMargin: 8
         anchors.bottom: parent.bottom
+        visible: !root.isCommandMode && root.activeCommandView === ""
 
         model: filteredModel
         clip: true
@@ -180,9 +292,9 @@ Item {
         anchors.topMargin: 8
         anchors.bottom: parent.bottom
         width: 6
+        visible: appListView.visible && appListView.contentHeight > appListView.height
         radius: 3
         color: ThemeManager.selectedTheme.colors.leftMenuBgColorV2
-        visible: appListView.contentHeight > appListView.height
 
         Rectangle {
             id: scrollHandle

--- a/config/quickshell/windows/leftwindow/applauncher/AppLauncher.qml
+++ b/config/quickshell/windows/leftwindow/applauncher/AppLauncher.qml
@@ -17,13 +17,67 @@ ColumnLayout {
     spacing: 0
     focus: true
 
+    // Command mode using shared registry
+    property bool isCommandMode: CommandsRegistry.isCommandMode(searchField.text)
+    property string commandText: CommandsRegistry.getCommandText(searchField.text)
+    property var filteredCommands: isCommandMode ? CommandsRegistry.filterCommands(commandText) : []
+
+    function executeCommand(cmd) {
+        if (cmd.isAction) {
+            // Handle action commands
+            if (cmd.action === "openSettings") {
+                EventBus.emit(Events.OPEN_SETTINGS);
+                EventBus.emit(Events.CLOSE_LEFTBAR);
+            }
+        } else if (cmd.view !== "") {
+            // Show the command view
+            root.activeCommandView = cmd.view;
+        }
+    }
+
+    // Current command view (empty = none, "wallpaper" = wallpaper selector, etc.)
+    property string activeCommandView: ""
+
+    // Auto-close command view when exiting command mode
+    onIsCommandModeChanged: {
+        if (!isCommandMode && activeCommandView !== "") {
+            activeCommandView = "";
+        }
+    }
+
     function gainFocus() {
         forceActiveFocus();
         focusTimer.start();
     // searchField.forceActiveFocus();
     }
 
+    function exitCommandView() {
+        activeCommandView = "";
+        searchField.text = "";
+        searchField.forceActiveFocus();
+    }
+
+    function resetState() {
+        searchField.text = "";
+        activeCommandView = "";
+    }
+
+    // Reset when parent becomes invisible
+    onVisibleChanged: {
+        if (!visible) {
+            resetState();
+        }
+    }
+
     Keys.onPressed: event => {
+        if (event.key === Qt.Key_Escape) {
+            if (activeCommandView !== "") {
+                exitCommandView();
+                event.accepted = true;
+                return;
+            }
+        }
+
         if (event.text && !searchField.activeFocus) {
             searchField.append(event.text);
             // searchField.forceActiveFocus();
@@ -38,7 +92,7 @@ ColumnLayout {
         // Layout.margins: 12
         Layout.topMargin: ThemeManager.selectedTheme.dimensions.menuWidgetsMargin
         Layout.bottomMargin: ThemeManager.selectedTheme.dimensions.menuWidgetsMargin
-        placeholderText: "Search for an application..."
+        placeholderText: "Search apps... or use > for commands"
         font.pixelSize: 16
 
         normalBackground: ThemeManager.selectedTheme.colors.leftMenuBgColorV1
@@ -57,6 +111,13 @@ ColumnLayout {
         // verticalAlignment: Text.VAlignment
 
         onAccepted: {
+            // Handle command mode
+            if (root.isCommandMode && root.filteredCommands.length > 0) {
+                const cmd = root.filteredCommands[0];
+                root.executeCommand(cmd);
+                return;
+            }
+
             if (processedModel.values.length > 1) {
                 const firstAppItem = processedModel.values[1];
                 root.launchSelectedApp(firstAppItem.appData.command, firstAppItem.appData.workingDirectory);
@@ -74,6 +135,7 @@ ColumnLayout {
         repeat: false
         onTriggered: {
             searchField.text = "";
+            root.activeCommandView = "";
         }
     }
 
@@ -127,12 +189,57 @@ ColumnLayout {
         }
     }
 
+    // Command suggestions list (shows when typing commands with >)
+    ListView {
+        id: commandListView
+        Layout.fillWidth: true
+        Layout.fillHeight: true
+        visible: root.isCommandMode && root.activeCommandView === ""
+
+        model: root.filteredCommands
+        clip: true
+        spacing: 4
+
+        delegate: CommandItem {
+            width: commandListView.width
+            commandData: modelData
+            isHighlighted: index === 0
+            onClicked: root.executeCommand(modelData)
+        }
+
+        Text {
+            anchors.centerIn: parent
+            visible: root.filteredCommands.length === 0
+            text: "No commands found"
+            font.pixelSize: 14
+            color: ThemeManager.selectedTheme.colors.subtleText
+        }
+    }
+
+    // Wallpaper Selector View
+    WallpaperSelector {
+        id: wallpaperSelector
+        Layout.fillWidth: true
+        Layout.fillHeight: true
+        visible: root.activeCommandView === "wallpaper"
+
+        onWallpaperSelected: path => {
+            root.exitCommandView();
+            EventBus.emit(Events.CLOSE_LEFTBAR);
+        }
+
+        onCloseRequested: {
+            root.exitCommandView();
+        }
+    }
+
     ScrollView {
         Layout.fillWidth: true
         Layout.fillHeight: true
         clip: true
         contentWidth: availableWidth
         ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
+        visible: !root.isCommandMode && root.activeCommandView === ""
 
         ListView {
             id: listView

--- a/config/quickshell/windows/settings/GeneralSettings.qml
+++ b/config/quickshell/windows/settings/GeneralSettings.qml
@@ -54,6 +54,10 @@ M3GroupBox {
         property bool enableHighRamAlert: false
         property bool playRamAlarmSound: false
         property int ramHighLoadThreshold: 90
+
+        // Launcher Layout
+        property bool useBottomLauncher: false
+        property int bottomLauncherWidth: 800
     }
 
     // ====================================================================
@@ -131,6 +135,9 @@ M3GroupBox {
         tempConfig.playRamAlarmSound = App.playRamAlarmSound;
         tempConfig.ramHighLoadThreshold = App.ramHighLoadThreshold;
 
+        tempConfig.useBottomLauncher = App.useBottomLauncher;
+        tempConfig.bottomLauncherWidth = App.bottomLauncherWidth;
+
         if (App.availableGeminiWeatherModels.length === 0)
             App.modelsManager.refreshAll();
 
@@ -161,7 +168,9 @@ M3GroupBox {
             "cpuHighLoadThreshold": tempConfig.cpuHighLoadThreshold,
             "enableHighRamAlert": tempConfig.enableHighRamAlert,
             "playRamAlarmSound": tempConfig.playRamAlarmSound,
-            "ramHighLoadThreshold": tempConfig.ramHighLoadThreshold
+            "ramHighLoadThreshold": tempConfig.ramHighLoadThreshold,
+            "useBottomLauncher": tempConfig.useBottomLauncher,
+            "bottomLauncherWidth": tempConfig.bottomLauncherWidth
         };
 
         App.updateConfigMultiple(dataToSave);
@@ -255,6 +264,79 @@ M3GroupBox {
                 }
             }
         }
+
+        Kirigami.Separator {
+            Layout.fillWidth: true
+            Layout.bottomMargin: selectedTheme.dimensions.spacingMedium
+        }
+
+        // =================================================================
+        // SECTION: LAUNCHER LAYOUT
+        // =================================================================
+        ColumnLayout {
+            Layout.fillWidth: true
+            spacing: selectedTheme.dimensions.spacingMedium
+            Layout.bottomMargin: selectedTheme.dimensions.spacingLarge
+
+            Controls.Label {
+                text: qsTr("Launcher Layout")
+                font.pixelSize: selectedTheme.typography.heading2Size
+                font.bold: true
+                color: selectedTheme.colors.primary
+            }
+
+            SettingSwitch {
+                label: qsTr("Use Bottom Launcher")
+                tooltip: qsTr("Toggle between side launcher (left panel) and bottom launcher.")
+                isChecked: tempConfig.useBottomLauncher
+                onIsCheckedChanged: tempConfig.useBottomLauncher = isChecked
+            }
+
+            Controls.Label {
+                text: tempConfig.useBottomLauncher
+                    ? qsTr("App launcher will open from the bottom of the screen.")
+                    : qsTr("App launcher will open from the left side panel.")
+                font.pixelSize: selectedTheme.typography.small
+                color: selectedTheme.colors.primary
+                opacity: 0.7
+            }
+            // Bottom Launcher Width
+            ColumnLayout {
+                Layout.fillWidth: true
+                spacing: 5
+                visible: tempConfig.useBottomLauncher
+
+                Controls.Label {
+                    text: qsTr("Launcher Width: %1px").arg(tempConfig.bottomLauncherWidth)
+                    font.bold: true
+                }
+
+                RowLayout {
+                    Layout.fillWidth: true
+                    spacing: 10
+
+                    Controls.Slider {
+                        id: launcherWidthSlider
+                        Layout.fillWidth: true
+                        from: 550
+                        to: 1200
+                        stepSize: 50
+                        value: tempConfig.bottomLauncherWidth
+                        onMoved: tempConfig.bottomLauncherWidth = value
+                    }
+
+                    Controls.Label {
+                        text: "550"
+                        font.pixelSize: selectedTheme.typography.small
+                        opacity: 0.6
+                    }
+                    Controls.Label {
+                        text: "1200"
+                        font.pixelSize: selectedTheme.typography.small
+                        opacity: 0.6
+                    }
+                }
+            }        }
 
         Kirigami.Separator {
             Layout.fillWidth: true


### PR DESCRIPTION
- Add BottomAppLauncher as alternative to side launcher
- Add useBottomLauncher config to switch between side/bottom modes
- Add bottomLauncherWidth setting (550-1200px)
- Update IPC toggleApplauncherMenu to respect launcher preference
- Simplify category filter with text labels instead of icons